### PR TITLE
feat: add Pagefind-powered site search behind a feature flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@
 | | |
 | --- | --- |
 | **Glass UI system** | Aurora backgrounds with reusable cards, buttons, badges, tags, sections & containers |
+| **Site search** | Pagefind-powered static search in a glass modal — open with the header button or <kbd>⌘K</kbd> |
 | **Light / dark** | System-aware theme toggle with no-flash startup and synced `theme-color` |
 | **Blog** | Pagination, tags, table of contents, reading time, share links, prev/next navigation |
 | **Portfolio** | Index with technology filters, case-study pages, and responsive galleries |
@@ -152,9 +153,14 @@ visibility, social links, and page options.
 | `features.landing` | `boolean` | Shows or hides the landing-page entry in the main header |
 | `features.rss` | `boolean` | Controls the RSS discovery `<link>`; the `/rss.xml` feed is always generated |
 | `features.sitemap` | `boolean` | Enables the `@astrojs/sitemap` integration in `astro.config.mjs` |
+| `features.search` | `boolean` | Enables Pagefind search: the `astro-pagefind` integration, the header search button, and the <kbd>⌘K</kbd> modal |
 
 Header navigation entries and the sitemap integration respond to these flags. The `/rss.xml`
 feed and content routes are always part of the static build.
+
+> [!TIP]
+> The search index is generated during `astro build`. In development the last built index
+> is served, so run `npm run build` once before `npm run dev` to try search locally.
 
 ### Social links
 

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,6 +1,7 @@
 import { defineConfig } from 'astro/config';
 import sitemap from '@astrojs/sitemap';
 import mdx from '@astrojs/mdx';
+import pagefind from 'astro-pagefind';
 import siteConfig from './src/site.config.ts';
 
 // https://astro.build/config
@@ -9,9 +10,15 @@ export default defineConfig({
   site: 'https://kpab.github.io',
   base: '/astro-haze',
   // MDX is always enabled so `.mdx` files in the content collections render
-  // (the blog/projects globs already accept them). Sitemap is gated by the
-  // `features.sitemap` flag in site.config.
-  integrations: [mdx(), ...(siteConfig.features.sitemap ? [sitemap()] : [])],
+  // (the blog/projects globs already accept them). Sitemap and Pagefind are
+  // gated by their `features` flags in site.config. Pagefind indexes the
+  // static output on build and serves the prebuilt index during `astro dev`
+  // (run a build once to generate it).
+  integrations: [
+    mdx(),
+    ...(siteConfig.features.sitemap ? [sitemap()] : []),
+    ...(siteConfig.features.search ? [pagefind()] : [])
+  ],
   output: 'static',
   build: {
     format: 'directory',

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@astrojs/rss": "^4.0.18",
         "@astrojs/sitemap": "^3.7.3",
         "astro": "^7.0.3",
+        "astro-pagefind": "^2.0.1",
         "zod": "^4.4.3"
       },
       "devDependencies": {
@@ -1683,6 +1684,113 @@
         "url": "https://github.com/sponsors/Boshen"
       }
     },
+    "node_modules/@pagefind/component-ui": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@pagefind/component-ui/-/component-ui-1.5.2.tgz",
+      "integrity": "sha512-t8/aE0tan4JiKa6cyhhSt/5qrEVwAK/qlYBHFpnRoq+qaFFVrhmXFFMY+r6n4GJtVIFCN2A5nUpeLN68cYjEjw==",
+      "license": "MIT",
+      "dependencies": {
+        "adequate-little-templates": "^1.0.2",
+        "bcp-47": "^2.1.0"
+      }
+    },
+    "node_modules/@pagefind/darwin-arm64": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@pagefind/darwin-arm64/-/darwin-arm64-1.5.2.tgz",
+      "integrity": "sha512-MXpI+7HsAdPkvJ0gk9xj9g541BCqBZOBbdwj9g6lB5LCj6kSV6nqDSjzcAJwvOsfu0fjwvC8hQU+ecfhp+MpiQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@pagefind/darwin-x64": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@pagefind/darwin-x64/-/darwin-x64-1.5.2.tgz",
+      "integrity": "sha512-IojxFWMEJe0RQ7PQ3KXQsPIImNsbpPYpoZ+QUDrL8fAl/O27IX+LVLs74/UzEZy5uA2LD8Nz1AiwKr72vrkZQw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@pagefind/freebsd-x64": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@pagefind/freebsd-x64/-/freebsd-x64-1.5.2.tgz",
+      "integrity": "sha512-7EVzo9+0w+2cbe671BtMj10UlNo83I+HrLVLfRxO731svHRJKUfJ/mo05gU14pe9PCfpKNQT8FS3Xc/oDN6pOA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@pagefind/linux-arm64": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@pagefind/linux-arm64/-/linux-arm64-1.5.2.tgz",
+      "integrity": "sha512-Ovt9+K35sqzn8H3ZMXGwls4TD/wMJuvRtShHIsmUQREmaxjrDEX7gHckRCrwYJ4XE1H1p6HkLz3wukrAnsfXQw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@pagefind/linux-x64": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@pagefind/linux-x64/-/linux-x64-1.5.2.tgz",
+      "integrity": "sha512-V+tFqHKXhQKq/WqPBD67AFy7scn1/aZID00ws4fSDd+1daSi5UHR9VVlRrOUYKxn3VuFQYRD7lYXdZK1WED1YA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@pagefind/windows-arm64": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@pagefind/windows-arm64/-/windows-arm64-1.5.2.tgz",
+      "integrity": "sha512-hN9Nh90fNW61nNRCW9ZyQrAj/mD0eRvmJ8NlTUzkbuW8kIzGJUi3cxjFkEcMZ5h/8FsKWD/VcouZl4yo1F7B6g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@pagefind/windows-x64": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@pagefind/windows-x64/-/windows-x64-1.5.2.tgz",
+      "integrity": "sha512-Fa2Iyw7kaDRzGMfNYNUXNW2zbL5FQVDgSOcbDHdzBrDEdpqOqg8TcZ68F22ol6NJ9IGzvUdmeyZypLW5dyhqsg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@polka/url": {
+      "version": "1.0.0-next.29",
+      "resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.29.tgz",
+      "integrity": "sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==",
+      "license": "MIT"
+    },
     "node_modules/@rolldown/binding-android-arm64": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.3.tgz",
@@ -2282,6 +2390,15 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/adequate-little-templates": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/adequate-little-templates/-/adequate-little-templates-1.0.2.tgz",
+      "integrity": "sha512-d0tFFG538l3Y4CElRKtticzrMr/OGohs32/nf3Ewn8rbTMBYwkVNe8mPdXWrDnMlz+ZVUFQjsTmsBD5zCtU4wg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/ajv": {
       "version": "8.20.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
@@ -2516,6 +2633,20 @@
         }
       }
     },
+    "node_modules/astro-pagefind": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/astro-pagefind/-/astro-pagefind-2.0.1.tgz",
+      "integrity": "sha512-zhMTctuVuKrYH1C0Xl+p8mhexEuxVrqfT8paQOAbKZFtgUIWAMtR2nCeU11ti4Rfeit16LhiCxZFwjOqYoiaNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@pagefind/component-ui": "^1.5.0",
+        "pagefind": "^1.5.0",
+        "sirv": "^3.0.0"
+      },
+      "peerDependencies": {
+        "astro": "^2.0.4 || ^3 || ^4 || ^5 || ^6 || ^7"
+      }
+    },
     "node_modules/axobject-query": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-4.1.0.tgz",
@@ -2530,6 +2661,21 @@
       "resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
       "integrity": "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==",
       "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/bcp-47": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/bcp-47/-/bcp-47-2.1.1.tgz",
+      "integrity": "sha512-KLw+H/gd2p4zly1X7Yh/qziuyae5/w/QFnvTng9eZL5fvszL7Whl3MBoWF8yxL7ksUjBfOD+OxkytiqbBpG+Fw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-alphabetical": "^2.0.0",
+        "is-alphanumerical": "^2.0.0",
+        "is-decimal": "^2.0.0"
+      },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
@@ -5393,6 +5539,24 @@
       "integrity": "sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA==",
       "license": "MIT"
     },
+    "node_modules/pagefind": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/pagefind/-/pagefind-1.5.2.tgz",
+      "integrity": "sha512-XTUaK0hXMCu2jszWE584JGQT7y284TmMV9l/HX3rnG5uo3rHI/uHU56XTyyyPFjeWEBxECbAi0CaFDJOONtG0Q==",
+      "license": "MIT",
+      "bin": {
+        "pagefind": "lib/runner/bin.cjs"
+      },
+      "optionalDependencies": {
+        "@pagefind/darwin-arm64": "1.5.2",
+        "@pagefind/darwin-x64": "1.5.2",
+        "@pagefind/freebsd-x64": "1.5.2",
+        "@pagefind/linux-arm64": "1.5.2",
+        "@pagefind/linux-x64": "1.5.2",
+        "@pagefind/windows-arm64": "1.5.2",
+        "@pagefind/windows-x64": "1.5.2"
+      }
+    },
     "node_modules/parse-entities": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-4.0.2.tgz",
@@ -6085,6 +6249,20 @@
         "node": ">=20"
       }
     },
+    "node_modules/sirv": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/sirv/-/sirv-3.0.2.tgz",
+      "integrity": "sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g==",
+      "license": "MIT",
+      "dependencies": {
+        "@polka/url": "^1.0.0-next.24",
+        "mrmime": "^2.0.0",
+        "totalist": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/sisteransi": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
@@ -6309,6 +6487,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/totalist": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/totalist/-/totalist-3.0.1.tgz",
+      "integrity": "sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/trim-lines": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@astrojs/rss": "^4.0.18",
     "@astrojs/sitemap": "^3.7.3",
     "astro": "^7.0.3",
+    "astro-pagefind": "^2.0.1",
     "zod": "^4.4.3"
   },
   "devDependencies": {

--- a/src/components/common/Footer.astro
+++ b/src/components/common/Footer.astro
@@ -21,7 +21,7 @@ const footerLinks = [
 ];
 ---
 
-<footer class="site-footer">
+<footer class="site-footer" data-pagefind-ignore>
   <GlassPanel variant="solid" padding="xl" radius="none">
     <div class="container footer-container">
       <!-- Main Footer Content -->

--- a/src/components/common/Header.astro
+++ b/src/components/common/Header.astro
@@ -24,7 +24,8 @@ const navItems = siteConfig.nav.main.filter(item => {
 });
 ---
 
-<header class="site-header glass-nav">
+<!-- data-pagefind-ignore keeps site chrome out of the search index -->
+<header class="site-header glass-nav" data-pagefind-ignore>
   <div class="container header-container">
     <!-- Logo/Brand -->
     <a href={withBase('/')} class="brand" aria-label="Home">
@@ -60,6 +61,34 @@ const navItems = siteConfig.nav.main.filter(item => {
         ))}
       </ul>
     </nav>
+
+    <!-- Search trigger (modal lives in BaseLayout) -->
+    {
+      siteConfig.features.search && (
+        <button
+          type="button"
+          class="search-toggle"
+          data-search-open
+          aria-label="Search this site (⌘K)"
+          title="Search (⌘K)"
+        >
+          <svg
+            width="20"
+            height="20"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            aria-hidden="true"
+          >
+            <circle cx="11" cy="11" r="8" />
+            <line x1="21" y1="21" x2="16.65" y2="16.65" />
+          </svg>
+        </button>
+      )
+    }
   </div>
 </header>
 
@@ -157,6 +186,27 @@ const navItems = siteConfig.nav.main.filter(item => {
     border-radius: var(--radius-full);
   }
 
+  /* Search trigger */
+  .search-toggle {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 44px;
+    height: 44px;
+    padding: 0;
+    color: var(--color-text-muted);
+    background: none;
+    border: none;
+    border-radius: var(--radius-md);
+    cursor: pointer;
+    transition: all var(--transition-fast);
+  }
+
+  .search-toggle:hover {
+    color: var(--color-text);
+    background: var(--glass-bg);
+  }
+
   /* Mobile styles */
   @media (max-width: 768px) {
     .nav-menu {
@@ -202,11 +252,24 @@ const navItems = siteConfig.nav.main.filter(item => {
     .nav-link.active::after {
       display: none;
     }
+
+    /* The nav dropdown is out of flow (position: fixed) on mobile, leaving
+       brand, hamburger and search as the flex items. Group the icons on the
+       right, search before the hamburger. */
+    .search-toggle {
+      order: 1;
+      margin-left: auto;
+    }
+
+    .menu-toggle {
+      order: 2;
+    }
   }
 
   /* Focus styles */
   .nav-link:focus-visible,
-  .brand:focus-visible {
+  .brand:focus-visible,
+  .search-toggle:focus-visible {
     outline: 2px solid var(--color-accent);
     outline-offset: 2px;
   }

--- a/src/components/common/SearchModal.astro
+++ b/src/components/common/SearchModal.astro
@@ -1,0 +1,371 @@
+---
+// Site-wide search modal backed by Pagefind. Opens from any element with a
+// `data-search-open` attribute or the ⌘K / Ctrl+K shortcut. The Pagefind
+// bundle is generated at build time (see the astro-pagefind integration in
+// astro.config.mjs), so it is lazy-loaded on first open — in `astro dev` the
+// prebuilt index from the last `astro build` is served, and a friendly hint
+// is shown when no index exists yet.
+---
+
+<dialog id="search-modal" class="search-modal" aria-label="Site search" data-pagefind-ignore>
+  <div class="search-box">
+    <form class="search-form" role="search">
+      <svg
+        class="search-icon"
+        width="20"
+        height="20"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="2"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        aria-hidden="true"
+      >
+        <circle cx="11" cy="11" r="8"></circle>
+        <line x1="21" y1="21" x2="16.65" y2="16.65"></line>
+      </svg>
+      <input
+        id="search-input"
+        type="search"
+        placeholder="Search posts, projects & pages…"
+        autocomplete="off"
+        spellcheck="false"
+        aria-label="Search this site"
+      />
+      <button type="button" class="search-close" data-search-close aria-label="Close search">
+        <kbd>Esc</kbd>
+      </button>
+    </form>
+
+    <div class="search-body">
+      <p id="search-status" class="search-status" role="status">
+        Start typing to search the whole site.
+      </p>
+      <ul id="search-results" class="search-results"></ul>
+    </div>
+
+    <footer class="search-footer">
+      <span><kbd>↑</kbd><kbd>↓</kbd> to navigate</span>
+      <span><kbd>Enter</kbd> to open</span>
+      <span><kbd>Esc</kbd> to close</span>
+    </footer>
+  </div>
+</dialog>
+
+<style>
+  .search-modal {
+    /* Centered near the top so results can grow downward. */
+    margin: min(12vh, 8rem) auto auto;
+    width: min(37.5rem, calc(100vw - 2 * var(--space-lg)));
+    padding: 0;
+    color: var(--color-text);
+    background: var(--glass-bg-solid);
+    backdrop-filter: blur(20px) saturate(var(--glass-sat));
+    -webkit-backdrop-filter: blur(20px) saturate(var(--glass-sat));
+    border: 1px solid var(--glass-border);
+    border-radius: var(--radius-lg);
+    box-shadow:
+      var(--glass-shadow),
+      inset 0 1px 0 0 rgba(255, 255, 255, 0.1);
+    z-index: var(--z-overlay);
+  }
+
+  .search-modal::backdrop {
+    background: rgba(0, 0, 0, 0.45);
+  }
+
+  @supports not (backdrop-filter: blur(1px)) {
+    .search-modal {
+      background: var(--color-bg);
+    }
+  }
+
+  .search-form {
+    display: flex;
+    align-items: center;
+    gap: var(--space-sm);
+    padding: var(--space-md) var(--space-lg);
+    border-bottom: 1px solid var(--glass-border);
+  }
+
+  .search-icon {
+    flex-shrink: 0;
+    color: var(--color-text-muted);
+  }
+
+  #search-input {
+    flex: 1;
+    min-width: 0;
+    padding: var(--space-xs) 0;
+    font-size: var(--text-lg);
+    font-family: var(--font-sans);
+    color: var(--color-text);
+    background: transparent;
+    border: none;
+    outline: none;
+  }
+
+  #search-input::placeholder {
+    color: var(--color-text-muted);
+  }
+
+  /* The dialog input is the obvious focus target; keep the box chrome quiet. */
+  #search-input:focus-visible {
+    outline: none;
+  }
+
+  #search-input::-webkit-search-cancel-button {
+    display: none;
+  }
+
+  .search-close {
+    padding: 0;
+    background: none;
+    border: none;
+    cursor: pointer;
+  }
+
+  .search-body {
+    max-height: min(50vh, 24rem);
+    overflow-y: auto;
+    overscroll-behavior: contain;
+    padding: var(--space-sm);
+  }
+
+  .search-status {
+    margin: 0;
+    padding: var(--space-md);
+    font-size: var(--text-sm);
+    color: var(--color-text-muted);
+  }
+
+  .search-status[hidden] {
+    display: none;
+  }
+
+  .search-results {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-xs);
+    margin: 0;
+    padding: 0;
+    list-style: none;
+  }
+
+  .search-results :global(.search-result) {
+    display: block;
+    padding: var(--space-sm) var(--space-md);
+    text-decoration: none;
+    border-radius: var(--radius-md);
+    transition: background var(--transition-fast);
+  }
+
+  .search-results :global(.search-result:hover),
+  .search-results :global(.search-result:focus-visible) {
+    background: var(--color-accent-glass);
+    outline: none;
+  }
+
+  .search-results :global(.search-result:focus-visible) {
+    box-shadow: inset 0 0 0 2px var(--color-accent);
+  }
+
+  .search-results :global(.search-result-title) {
+    display: block;
+    font-weight: 600;
+    color: var(--color-text);
+  }
+
+  .search-results :global(.search-result-excerpt) {
+    display: block;
+    margin-top: var(--space-xs);
+    font-size: var(--text-sm);
+    color: var(--color-text-muted);
+  }
+
+  .search-results :global(.search-result-excerpt mark) {
+    background: var(--color-accent-glass);
+    color: var(--color-accent-text);
+    border-radius: var(--radius-sm);
+    padding: 0 0.15em;
+  }
+
+  .search-footer {
+    display: flex;
+    gap: var(--space-lg);
+    padding: var(--space-sm) var(--space-lg);
+    border-top: 1px solid var(--glass-border);
+    font-size: var(--text-xs);
+    color: var(--color-text-muted);
+  }
+
+  kbd {
+    display: inline-block;
+    min-width: 1.4em;
+    padding: 0.1em 0.4em;
+    margin-right: 0.25em;
+    font-family: var(--font-mono);
+    font-size: 0.85em;
+    text-align: center;
+    color: var(--color-text-muted);
+    background: var(--glass-bg);
+    border: 1px solid var(--glass-border);
+    border-radius: var(--radius-sm);
+  }
+</style>
+
+<script>
+  const dialog = document.getElementById('search-modal') as HTMLDialogElement | null;
+  const input = document.getElementById('search-input') as HTMLInputElement | null;
+  const status = document.getElementById('search-status');
+  const resultsList = document.getElementById('search-results');
+
+  // BASE_URL may or may not carry a trailing slash depending on config;
+  // normalize so concatenation below is predictable (same as lib/url.ts).
+  const BASE = import.meta.env.BASE_URL.replace(/\/$/, '');
+  const MAX_RESULTS = 8;
+
+  // Pagefind's client bundle only exists after a production build, so it is
+  // imported lazily the first time the modal opens.
+  type Pagefind = {
+    options: (opts: Record<string, unknown>) => Promise<void>;
+    init: () => void;
+    debouncedSearch: (
+      query: string,
+      options?: Record<string, unknown>,
+      debounceMs?: number
+    ) => Promise<{ results: Array<{ data: () => Promise<PagefindDocument> }> } | null>;
+  };
+  type PagefindDocument = {
+    url: string;
+    excerpt: string;
+    meta: { title?: string };
+  };
+
+  let pagefind: Pagefind | null = null;
+  let loadFailed = false;
+
+  async function loadPagefind(): Promise<Pagefind | null> {
+    if (pagefind || loadFailed) return pagefind;
+    try {
+      pagefind = (await import(/* @vite-ignore */ `${BASE}/pagefind/pagefind.js`)) as Pagefind;
+      // Result URLs in the index are root-relative to the built site, so the
+      // deploy base has to be prepended for project-site hosting.
+      await pagefind.options({ baseUrl: `${BASE}/` });
+      pagefind.init();
+    } catch {
+      loadFailed = true;
+      showStatus(
+        'Search index not found. It is generated at build time — run a production build once, then reload.'
+      );
+    }
+    return pagefind;
+  }
+
+  function showStatus(message: string) {
+    if (!status || !resultsList) return;
+    status.textContent = message;
+    status.hidden = false;
+    resultsList.replaceChildren();
+  }
+
+  function renderResults(docs: PagefindDocument[], query: string) {
+    if (!status || !resultsList) return;
+    if (docs.length === 0) {
+      showStatus(`No results for “${query}”.`);
+      return;
+    }
+    status.hidden = true;
+    resultsList.replaceChildren(
+      ...docs.map((doc) => {
+        const item = document.createElement('li');
+        const link = document.createElement('a');
+        link.className = 'search-result';
+        link.href = doc.url;
+
+        const title = document.createElement('span');
+        title.className = 'search-result-title';
+        title.textContent = doc.meta.title ?? doc.url;
+
+        const excerpt = document.createElement('span');
+        excerpt.className = 'search-result-excerpt';
+        // Pagefind excerpts are HTML with <mark> highlights, produced from
+        // this site's own built pages.
+        excerpt.innerHTML = doc.excerpt;
+
+        link.append(title, excerpt);
+        item.appendChild(link);
+        return item;
+      })
+    );
+  }
+
+  async function runSearch(query: string) {
+    if (!query.trim()) {
+      showStatus('Start typing to search the whole site.');
+      return;
+    }
+    const pf = await loadPagefind();
+    if (!pf) return;
+    // debouncedSearch resolves to null when superseded by newer input.
+    const search = await pf.debouncedSearch(query, {}, 250);
+    if (!search) return;
+    const docs = await Promise.all(search.results.slice(0, MAX_RESULTS).map((r) => r.data()));
+    renderResults(docs, query);
+  }
+
+  function openModal() {
+    if (!dialog || dialog.open) return;
+    dialog.showModal();
+    document.documentElement.style.overflow = 'hidden';
+    input?.select();
+    loadPagefind();
+  }
+
+  input?.addEventListener('input', () => runSearch(input.value));
+
+  dialog?.addEventListener('close', () => {
+    document.documentElement.style.overflow = '';
+  });
+
+  // Close when the backdrop (the dialog element itself) is clicked.
+  dialog?.addEventListener('click', (e) => {
+    if (e.target === dialog) dialog.close();
+  });
+
+  dialog
+    ?.querySelector('[data-search-close]')
+    ?.addEventListener('click', () => dialog.close());
+
+  // Roving focus between the input and result links with ↑/↓.
+  dialog?.addEventListener('keydown', (e) => {
+    if (e.key !== 'ArrowDown' && e.key !== 'ArrowUp') return;
+    e.preventDefault();
+    const links = Array.from(
+      resultsList?.querySelectorAll<HTMLAnchorElement>('.search-result') ?? []
+    );
+    if (!input || links.length === 0) return;
+    const stops: HTMLElement[] = [input, ...links];
+    const current = stops.indexOf(document.activeElement as HTMLElement);
+    const delta = e.key === 'ArrowDown' ? 1 : -1;
+    const next = (current + delta + stops.length) % stops.length;
+    stops[next]?.focus();
+  });
+
+  // Any trigger on the page opens the modal; ⌘K / Ctrl+K toggles it.
+  document.querySelectorAll('[data-search-open]').forEach((el) => {
+    el.addEventListener('click', openModal);
+  });
+
+  window.addEventListener('keydown', (e) => {
+    if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 'k') {
+      e.preventDefault();
+      if (dialog?.open) {
+        dialog.close();
+      } else {
+        openModal();
+      }
+    }
+  });
+</script>

--- a/src/components/common/SearchModal.astro
+++ b/src/components/common/SearchModal.astro
@@ -246,10 +246,19 @@
   let pagefind: Pagefind | null = null;
   let loadFailed = false;
 
+  // A plain `import()` here gets rewritten by Vite's preload helper when this
+  // script is bundled (and `@vite-ignore` comments don't survive processing),
+  // which leaves an unresolved __VITE_PRELOAD__ placeholder that throws at
+  // runtime. The Function indirection keeps the dynamic import opaque to the
+  // bundler so the browser-native import() reaches the runtime untouched.
+  const dynamicImport = new Function('s', 'return import(s)') as (
+    s: string
+  ) => Promise<unknown>;
+
   async function loadPagefind(): Promise<Pagefind | null> {
     if (pagefind || loadFailed) return pagefind;
     try {
-      pagefind = (await import(/* @vite-ignore */ `${BASE}/pagefind/pagefind.js`)) as Pagefind;
+      pagefind = (await dynamicImport(`${BASE}/pagefind/pagefind.js`)) as Pagefind;
       // Result URLs in the index are root-relative to the built site, so the
       // deploy base has to be prepended for project-site hosting.
       await pagefind.options({ baseUrl: `${BASE}/` });

--- a/src/components/common/SearchModal.astro
+++ b/src/components/common/SearchModal.astro
@@ -312,6 +312,8 @@
     const search = await pf.debouncedSearch(query, {}, 250);
     if (!search) return;
     const docs = await Promise.all(search.results.slice(0, MAX_RESULTS).map((r) => r.data()));
+    // The query may have changed (or been cleared) while result data loaded.
+    if (input && input.value !== query) return;
     renderResults(docs, query);
   }
 
@@ -323,7 +325,7 @@
     loadPagefind();
   }
 
-  input?.addEventListener('input', () => runSearch(input.value));
+  input?.addEventListener('input', (e) => runSearch((e.target as HTMLInputElement).value));
 
   dialog?.addEventListener('close', () => {
     document.documentElement.style.overflow = '';

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -5,6 +5,7 @@ import { withBase } from '@/lib/url';
 import Seo from '@/components/common/Seo.astro';
 import AuroraBackground from '@/components/common/AuroraBackground.astro';
 import ThemeToggle from '@/components/common/ThemeToggle.astro';
+import SearchModal from '@/components/common/SearchModal.astro';
 
 export interface Props {
   title?: string;
@@ -81,7 +82,7 @@ const props = Astro.props;
   </head>
   <body>
     <!-- Skip to content link -->
-    <a href="#main" class="skip-link">Skip to content</a>
+    <a href="#main" class="skip-link" data-pagefind-ignore>Skip to content</a>
 
     <!-- Aurora Background -->
     <AuroraBackground intensity="medium" animated={true} />
@@ -97,6 +98,9 @@ const props = Astro.props;
         </div>
       )
     }
+
+    <!-- Site search (Pagefind) — opened from the header button or ⌘K -->
+    {siteConfig.features.search && <SearchModal />}
   </body>
 </html>
 

--- a/src/site.config.ts
+++ b/src/site.config.ts
@@ -29,6 +29,7 @@ export interface SiteConfig {
     landing: boolean;
     rss: boolean;
     sitemap: boolean;
+    search: boolean;
   };
 
   // Social links
@@ -87,7 +88,8 @@ const siteConfig: SiteConfig = {
     portfolio: true,
     landing: true,
     rss: true,
-    sitemap: true
+    sitemap: true,
+    search: true
   },
 
   social: {


### PR DESCRIPTION
## Summary

Adds static full-text search to the theme, powered by [Pagefind](https://pagefind.app) via the `astro-pagefind` integration.

- **Build-time index** — the integration hooks `astro build`, so the existing `withastro/action` deploy workflow needs no changes. Gated by a new `features.search` flag in `site.config.ts` (same pattern as `features.sitemap`).
- **Glass search modal** — a native `<dialog>` styled with the existing glass tokens. Opens from a new header search button or ⌘K / Ctrl+K, with ↑/↓ roving focus over results, Esc / backdrop-click to close, and a friendly hint in dev when no index has been built yet.
- **Zero JS for non-searchers** — the Pagefind bundle is lazy-loaded on first open, via a bundler-opaque dynamic import (a plain `import()` gets rewritten by Vite's preload helper and breaks when the script is inlined; see the last commit).
- **Focused index** — site chrome (header, footer, skip link, the modal itself) is marked `data-pagefind-ignore`, so excerpts only surface page content.
- README documents the feature and the flag.

## Verification

- `npm run check` — 0 errors / 0 warnings (49 files)
- `npm run build` — Pagefind indexed 19 pages into `dist/pagefind`
- Browser (preview): ⌘K opens the modal with focus in the input; a broken first iteration of the Pagefind import was caught this way and fixed in `7be6035`
- [x] Re-verify search results end-to-end against a rebuild that includes `7be6035` (result links must carry the `/astro-haze/` base prefix)