### PR TITLE
chore: release v1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,30 @@
+# Changelog
+
+All notable changes to this project are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [1.1.0] - 2026-07-17
+
+### Added
+
+- Pagefind-powered static site search behind a new `features.search` flag ([#1](https://github.com/kpab/astro-haze/pull/1))
+  - Search index generated during `astro build` via the `astro-pagefind` integration — no deploy-workflow changes needed
+  - Glass search modal (native `<dialog>`) opened from a header button or <kbd>⌘K</kbd> / <kbd>Ctrl+K</kbd>, with ↑/↓ result navigation
+  - Pagefind bundle lazy-loaded on first open; site chrome excluded from the index with `data-pagefind-ignore`
+
+## [1.0.0] - 2026-06-30
+
+### Added
+
+- Initial release: glassmorphism multi-purpose Astro 7 theme
+  - Reusable glass UI system with aurora backgrounds, light/dark theme toggle
+  - Paginated blog with tags, table of contents, reading time and share links
+  - Portfolio with technology filters, case-study pages and responsive galleries
+  - Config-driven e-commerce landing page
+  - SEO (canonical, Open Graph, Twitter cards, JSON-LD), RSS feed and XML sitemap
+  - Optimized images (AVIF/WebP via `astro:assets`), accessibility and reduced-motion support
+
+[1.1.0]: https://github.com/kpab/astro-haze/compare/v1.0.0...v1.1.0
+[1.0.0]: https://github.com/kpab/astro-haze/releases/tag/v1.0.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "astro-haze",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "astro-haze",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
         "@astrojs/mdx": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "astro-haze",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "A glassmorphism multi-purpose theme for Astro 7 - Blog, Portfolio & Landing Pages",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary

- Bump `package.json` / `package-lock.json` to **1.1.0** (minor: adds Pagefind site search, #1)
- Add a [Keep a Changelog](https://keepachangelog.com)-style `CHANGELOG.md` covering 1.0.0 and 1.1.0

After merging, the `v1.1.0` tag will be created on the merge commit.