### PR TITLE
fix: v1.1.1 バグ修正まとめ（#17-#25）

### DIFF
--- a/README.md
+++ b/README.md
@@ -370,8 +370,14 @@ To deploy under a different repo, user site, or custom domain, update `site`, `b
 (`<user>.github.io`) or a custom domain, set `base: '/'`.
 
 > [!TIP]
-> The `public/_headers` file is for Cloudflare Pages and is ignored by GitHub Pages; it's
-> kept for users deploying there instead.
+> The `public/_headers` file is for Cloudflare Pages / Netlify and is ignored by GitHub Pages
+> (served there as a plain static file, so none of its rules apply); it's kept for users
+> deploying to one of those instead.
+>
+> Likewise, crawlers only fetch `robots.txt` from the origin root
+> (`https://<user>.github.io/robots.txt`), never from a project page's subpath, so
+> `public/robots.txt` is not read on a GitHub Pages project site. Submit the sitemap URL
+> directly to Google Search Console / Bing Webmaster Tools instead of relying on this file.
 
 ---
 

--- a/public/_headers
+++ b/public/_headers
@@ -1,4 +1,8 @@
 # Cloudflare Pages headers — https://developers.cloudflare.com/pages/configuration/headers/
+#
+# Cloudflare Pages / Netlify only. On GitHub Pages this file is served as a
+# plain static file and none of the rules below are applied — the headers
+# and the /_astro/* immutable cache are simply not in effect there.
 
 /*
   X-Content-Type-Options: nosniff

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,3 +1,8 @@
+# Note: on a GitHub Pages project site (https://<user>.github.io/<repo>/),
+# crawlers only ever look for robots.txt at the origin root
+# (https://<user>.github.io/robots.txt), so this file is not read here.
+# Submit the sitemap URL below directly to Google Search Console / Bing
+# Webmaster Tools instead of relying on this file's Sitemap: line.
 User-agent: *
 Allow: /
 

--- a/src/components/blog/BlogCard.astro
+++ b/src/components/blog/BlogCard.astro
@@ -3,6 +3,7 @@ import type { ImageMetadata } from 'astro';
 import Tag from '@/components/ui/Tag.astro';
 import Picture from '@/components/ui/Picture.astro';
 import Badge from '@/components/ui/Badge.astro';
+import { formatDate } from '@/lib/date';
 
 export interface Props {
   title: string;
@@ -28,11 +29,7 @@ const {
   featured = false,
 } = Astro.props;
 
-const formattedDate = pubDate.toLocaleDateString('en-US', {
-  year: 'numeric',
-  month: 'long',
-  day: 'numeric',
-});
+const formattedDate = formatDate(pubDate);
 ---
 
 <article class="blog-card glass-card">

--- a/src/components/common/Footer.astro
+++ b/src/components/common/Footer.astro
@@ -13,12 +13,11 @@ const socialIcons = {
   youtube: `<svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M22.54 6.42a2.78 2.78 0 0 0-1.94-2C18.88 4 12 4 12 4s-6.88 0-8.6.46a2.78 2.78 0 0 0-1.94 2A29 29 0 0 0 1 11.75a29 29 0 0 0 .46 5.33A2.78 2.78 0 0 0 3.4 19c1.72.46 8.6.46 8.6.46s6.88 0 8.6-.46a2.78 2.78 0 0 0 1.94-2 29 29 0 0 0 .46-5.25 29 29 0 0 0-.46-5.33z"></path><polygon points="9.75 15.02 15.5 11.75 9.75 8.48 9.75 15.02"></polygon></svg>`
 };
 
-const footerLinks = [
-  { name: 'Privacy', href: '/privacy' },
-  { name: 'Terms', href: '/terms' },
-  { name: 'Sitemap', href: '/sitemap-index.xml' },
-  { name: 'RSS', href: '/rss.xml' }
-];
+const footerLinks = siteConfig.footer.links.filter((link) => {
+  if (link.href === '/sitemap-index.xml') return siteConfig.features.sitemap;
+  if (link.href === '/rss.xml') return siteConfig.features.rss;
+  return true;
+});
 ---
 
 <footer class="site-footer" data-pagefind-ignore>

--- a/src/components/common/Footer.astro
+++ b/src/components/common/Footer.astro
@@ -1,6 +1,7 @@
 ---
 import siteConfig from '@/site.config';
 import { withBase } from '@/lib/url';
+import { getEnabledNavItems } from '@/lib/nav';
 import GlassPanel from './GlassPanel.astro';
 
 const currentYear = new Date().getFullYear();
@@ -12,6 +13,8 @@ const socialIcons = {
   instagram: `<svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="2" width="20" height="20" rx="5" ry="5"></rect><path d="M16 11.37A4 4 0 1 1 12.63 8 4 4 0 0 1 16 11.37z"></path><line x1="17.5" y1="6.5" x2="17.51" y2="6.5"></line></svg>`,
   youtube: `<svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M22.54 6.42a2.78 2.78 0 0 0-1.94-2C18.88 4 12 4 12 4s-6.88 0-8.6.46a2.78 2.78 0 0 0-1.94 2A29 29 0 0 0 1 11.75a29 29 0 0 0 .46 5.33A2.78 2.78 0 0 0 3.4 19c1.72.46 8.6.46 8.6.46s6.88 0 8.6-.46a2.78 2.78 0 0 0 1.94-2 29 29 0 0 0 .46-5.25 29 29 0 0 0-.46-5.33z"></path><polygon points="9.75 15.02 15.5 11.75 9.75 8.48 9.75 15.02"></polygon></svg>`
 };
+
+const navItems = getEnabledNavItems();
 
 const footerLinks = siteConfig.footer.links.filter((link) => {
   if (link.href === '/sitemap-index.xml') return siteConfig.features.sitemap;
@@ -35,7 +38,7 @@ const footerLinks = siteConfig.footer.links.filter((link) => {
         <div class="footer-section">
           <h4 class="footer-subtitle">Quick Links</h4>
           <ul class="footer-links">
-            {siteConfig.nav.main.map((item) => (
+            {navItems.map((item) => (
               <li>
                 <a href={withBase(item.href)} class="footer-link">
                   {item.name}

--- a/src/components/common/Header.astro
+++ b/src/components/common/Header.astro
@@ -1,6 +1,7 @@
 ---
 import siteConfig from '@/site.config';
 import { withBase } from '@/lib/url';
+import { getEnabledNavItems } from '@/lib/nav';
 
 const currentPath = Astro.url.pathname;
 
@@ -15,13 +16,7 @@ function isActive(href: string): boolean {
   return currentPath === target || currentPath.startsWith(target + '/');
 }
 
-const navItems = siteConfig.nav.main.filter(item => {
-  // Filter out disabled features
-  if (item.href === '/blog' && !siteConfig.features.blog) return false;
-  if (item.href === '/work' && !siteConfig.features.portfolio) return false;
-  if (item.href === '/landing' && !siteConfig.features.landing) return false;
-  return true;
-});
+const navItems = getEnabledNavItems();
 ---
 
 <!-- data-pagefind-ignore keeps site chrome out of the search index -->

--- a/src/components/ui/Picture.astro
+++ b/src/components/ui/Picture.astro
@@ -1,6 +1,7 @@
 ---
 import { Picture as AstroPicture } from 'astro:assets';
 import type { ImageMetadata } from 'astro';
+import { withBase } from '@/lib/url';
 
 export interface Props {
   src: ImageMetadata | string;
@@ -51,7 +52,7 @@ const resolvedWidths = widths ?? (sizes ? [400, 800, 1200] : undefined);
     />
   ) : (
     <img
-      src={src as string}
+      src={withBase(src as string)}
       alt={alt}
       width={width}
       height={height}

--- a/src/lib/date.ts
+++ b/src/lib/date.ts
@@ -1,0 +1,12 @@
+// pubDate/updatedDate come from frontmatter as date-only values, coerced to
+// midnight UTC (src/content.config.ts). Formatting in the build host's local
+// timezone would shift the displayed date by a day west of UTC, so timeZone
+// is pinned to UTC here rather than left to the environment default.
+export function formatDate(date: Date): string {
+  return date.toLocaleDateString('en-US', {
+    timeZone: 'UTC',
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+  });
+}

--- a/src/lib/nav.ts
+++ b/src/lib/nav.ts
@@ -1,0 +1,18 @@
+import siteConfig from '@/site.config';
+
+// Maps a nav href to the feature flag that gates it. Hrefs without an entry
+// here are always shown.
+const FEATURE_BY_HREF: Record<string, keyof typeof siteConfig.features> = {
+  '/blog': 'blog',
+  '/work': 'portfolio',
+  '/landing': 'landing',
+};
+
+// Shared by Header and Footer so disabling a feature (e.g. features.blog)
+// removes its nav link everywhere instead of only from the main nav.
+export function getEnabledNavItems(): Array<{ name: string; href: string }> {
+  return siteConfig.nav.main.filter((item) => {
+    const feature = FEATURE_BY_HREF[item.href];
+    return !feature || siteConfig.features[feature];
+  });
+}

--- a/src/lib/posts.ts
+++ b/src/lib/posts.ts
@@ -33,6 +33,25 @@ export async function getPublishedPosts(): Promise<Post[]> {
 }
 
 /**
+ * Split off up to `max` featured posts and return the rest as a single pool.
+ * Both the blog index (page 1) and `/blog/page/[page]` must exclude the same
+ * featured posts from their pagination source — filtering only within one
+ * page's slice window still lets a featured post that falls in another
+ * page's window appear twice (once in the Featured section, once in that
+ * page's grid), since featured posts are picked from the full list, not from
+ * whichever page happens to contain them.
+ */
+export function splitFeatured(
+  posts: Post[],
+  max = 2
+): { featured: Post[]; rest: Post[] } {
+  const featured = posts.filter((p) => p.data.featured).slice(0, max);
+  const featuredIds = new Set(featured.map((p) => p.id));
+  const rest = posts.filter((p) => !featuredIds.has(p.id));
+  return { featured, rest };
+}
+
+/**
  * Given a newest-first list, find the chronologically newer/older neighbours
  * of the post with `id` for prev/next navigation.
  */

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -67,7 +67,7 @@ const stack = [
 ---
 
 <BaseLayout
-  title={`About | ${siteConfig.name}`}
+  title="About"
   description={`${siteConfig.name} is a modular Astro 7 theme for publishing stories, projects, and focused landing pages.`}
 >
   <Header />

--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -10,6 +10,7 @@ import Tag from '@/components/ui/Tag.astro';
 import Picture from '@/components/ui/Picture.astro';
 import Toc from '@/components/blog/Toc.astro';
 import { withBase } from '@/lib/url';
+import { formatDate } from '@/lib/date';
 import {
   getPublishedPosts,
   getAdjacentPosts,
@@ -32,9 +33,8 @@ const allPosts = await getPublishedPosts();
 const { newer, older } = getAdjacentPosts(allPosts, post.id);
 
 const minutes = readingTime(post.body);
-const dateOpts = { year: 'numeric', month: 'long', day: 'numeric' } as const;
-const formattedDate = post.data.pubDate.toLocaleDateString('en-US', dateOpts);
-const updatedDate = post.data.updatedDate?.toLocaleDateString('en-US', dateOpts);
+const formattedDate = formatDate(post.data.pubDate);
+const updatedDate = post.data.updatedDate ? formatDate(post.data.updatedDate) : undefined;
 
 const showToc = siteConfig.blog.showToc && headings.length > 0;
 const tweetUrl = `https://twitter.com/intent/tweet?text=${encodeURIComponent(

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -6,22 +6,19 @@ import GlassPanel from '@/components/common/GlassPanel.astro';
 import Container from '@/components/ui/Container.astro';
 import PostGrid from '@/components/blog/PostGrid.astro';
 import Pagination from '@/components/blog/Pagination.astro';
-import { getPublishedPosts } from '@/lib/posts';
+import { getPublishedPosts, splitFeatured } from '@/lib/posts';
 import siteConfig from '@/site.config';
 
 const allPosts = await getPublishedPosts();
 const perPage = siteConfig.blog.postsPerPage;
-const totalPages = Math.max(1, Math.ceil(allPosts.length / perPage));
 
-const featured = allPosts.filter((p) => p.data.featured).slice(0, 2);
-// Page 1 only — posts already shown in Featured are dropped from this grid
-// so they don't appear twice. The filter runs after slicing to the page-1
-// window (not before) so it never pulls a post forward from page 2, which
-// would duplicate it there instead. Pagination (totalPages, and page 2+ in
-// page/[page].astro) still counts every post, so page 1 may show fewer than
-// `perPage` posts when featured posts fall within its window.
-const featuredIds = new Set(featured.map((p) => p.id));
-const pagePosts = allPosts.slice(0, perPage).filter((p) => !featuredIds.has(p.id));
+// Featured posts are pulled out of the pool before pagination, and
+// page/[page].astro does the same split, so a featured post never
+// reappears in a paginated grid regardless of where it falls in the
+// full, date-sorted list.
+const { featured, rest } = splitFeatured(allPosts);
+const totalPages = Math.max(1, Math.ceil(rest.length / perPage));
+const pagePosts = rest.slice(0, perPage);
 ---
 
 <BaseLayout

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -14,7 +14,14 @@ const perPage = siteConfig.blog.postsPerPage;
 const totalPages = Math.max(1, Math.ceil(allPosts.length / perPage));
 
 const featured = allPosts.filter((p) => p.data.featured).slice(0, 2);
-const pagePosts = allPosts.slice(0, perPage);
+// Page 1 only — posts already shown in Featured are dropped from this grid
+// so they don't appear twice. The filter runs after slicing to the page-1
+// window (not before) so it never pulls a post forward from page 2, which
+// would duplicate it there instead. Pagination (totalPages, and page 2+ in
+// page/[page].astro) still counts every post, so page 1 may show fewer than
+// `perPage` posts when featured posts fall within its window.
+const featuredIds = new Set(featured.map((p) => p.id));
+const pagePosts = allPosts.slice(0, perPage).filter((p) => !featuredIds.has(p.id));
 ---
 
 <BaseLayout

--- a/src/pages/blog/page/[page].astro
+++ b/src/pages/blog/page/[page].astro
@@ -6,13 +6,18 @@ import Footer from '@/components/common/Footer.astro';
 import Container from '@/components/ui/Container.astro';
 import PostGrid from '@/components/blog/PostGrid.astro';
 import Pagination from '@/components/blog/Pagination.astro';
-import { getPublishedPosts, type Post } from '@/lib/posts';
+import { getPublishedPosts, splitFeatured, type Post } from '@/lib/posts';
 import siteConfig from '@/site.config';
 
 export const getStaticPaths = (async () => {
-  const posts = await getPublishedPosts();
+  const allPosts = await getPublishedPosts();
   const perPage = siteConfig.blog.postsPerPage;
-  const totalPages = Math.max(1, Math.ceil(posts.length / perPage));
+
+  // Must match the same split as blog/index.astro (page 1) — otherwise a
+  // featured post that falls outside page 1's window would still be
+  // paginated here, duplicating it against the Featured section on /blog.
+  const { rest } = splitFeatured(allPosts);
+  const totalPages = Math.max(1, Math.ceil(rest.length / perPage));
 
   // Page 1 lives at /blog (index.astro); generate 2..totalPages here.
   const paths = [];
@@ -20,7 +25,7 @@ export const getStaticPaths = (async () => {
     paths.push({
       params: { page: String(page) },
       props: {
-        posts: posts.slice((page - 1) * perPage, page * perPage),
+        posts: rest.slice((page - 1) * perPage, page * perPage),
         currentPage: page,
         totalPages,
       },

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -42,7 +42,7 @@ const showcases = [
 ---
 
 <BaseLayout
-  title={`${siteConfig.name} — One system, three ways to publish`}
+  title="One system, three ways to publish"
   description="A production-ready Astro theme for editorial blogs, portfolios, and focused landing pages."
 >
   <Header />

--- a/src/pages/landing/index.astro
+++ b/src/pages/landing/index.astro
@@ -1,7 +1,6 @@
 ---
 import { getCollection } from 'astro:content';
 import BaseLayout from '@/layouts/BaseLayout.astro';
-import siteConfig from '@/site.config';
 import Header from '@/components/common/Header.astro';
 import Footer from '@/components/common/Footer.astro';
 import Hero from '@/components/landing/Hero.astro';
@@ -23,7 +22,7 @@ const { hero, features, benefits, pricing, gallery, testimonials, faq, finalCta 
 ---
 
 <BaseLayout
-  title={`${hero.title} | ${siteConfig.name}`}
+  title={hero.title}
   description={hero.description}
 >
   <Header />

--- a/src/pages/rss.xml.ts
+++ b/src/pages/rss.xml.ts
@@ -7,10 +7,17 @@ import siteConfig from '@/site.config';
 export async function GET(context: APIContext) {
   const posts = await getPublishedPosts();
 
+  // context.site is astro.config's `site` (no base). @astrojs/rss uses this
+  // for the channel <link>, so the base must be appended here or the feed's
+  // homepage points at the origin root instead of the project site.
+  const site = context.site
+    ? new URL(import.meta.env.BASE_URL, context.site)
+    : siteConfig.url;
+
   return rss({
     title: `${siteConfig.name} — Blog`,
     description: siteConfig.description,
-    site: context.site ?? siteConfig.url,
+    site,
     items: posts.map((post) => ({
       title: post.data.title,
       description: post.data.description,

--- a/src/pages/work/[...slug].astro
+++ b/src/pages/work/[...slug].astro
@@ -38,7 +38,7 @@ const projectLinks = [
   },
   project.data.links?.case && {
     label: 'Read case study',
-    href: project.data.links.case,
+    href: withBase(project.data.links.case),
     external: false,
   },
 ].filter((link): link is { label: string; href: string; external: boolean } => Boolean(link));

--- a/src/site.config.ts
+++ b/src/site.config.ts
@@ -3,6 +3,9 @@ export interface SiteConfig {
   title: string;
   description: string;
   author: string;
+  // Fallback only, used when astro.config.mjs's `site` is unavailable
+  // (e.g. context.site during a dev/preview run without it set). The
+  // canonical site + base configuration lives in astro.config.mjs.
   url: string;
   ogImage: string;
   twitterHandle: string;

--- a/src/site.config.ts
+++ b/src/site.config.ts
@@ -56,6 +56,14 @@ export interface SiteConfig {
     showTechStack: boolean;
     showYear: boolean;
   };
+
+  // Footer settings
+  footer: {
+    links: Array<{
+      name: string;
+      href: string;
+    }>;
+  };
 }
 
 const siteConfig: SiteConfig = {
@@ -110,6 +118,15 @@ const siteConfig: SiteConfig = {
     projectsPerPage: 9,
     showTechStack: true,
     showYear: true
+  },
+
+  footer: {
+    // Privacy/Terms are intentionally omitted by default — this theme ships
+    // without those pages, so add them here only once the pages exist.
+    links: [
+      { name: 'Sitemap', href: '/sitemap-index.xml' },
+      { name: 'RSS', href: '/rss.xml' }
+    ]
   }
 };
 

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -25,6 +25,7 @@ body {
   background-color: var(--color-bg);
   min-height: 100vh;
   overflow-x: hidden;
+  overflow-wrap: break-word;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
@@ -272,7 +273,11 @@ button {
 
 /* Table styles */
 .prose table {
+  display: block;
   width: 100%;
+  max-width: 100%;
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
   border-collapse: collapse;
   margin: var(--space-lg) 0;
 }


### PR DESCRIPTION
## Summary
v1.1.1 マイルストーンの9件のissueに対応。

- Fixes #17 — SEOタイトルにサイト名が二重付与される問題
- Fixes #18 — Footerの /privacy /terms デッドリンク
- Fixes #19 — Footerナビがfeatureフラグでフィルタされず404を生成しうる問題
- Fixes #20 — RSS channel linkがbase抜けのオリジンルートを指す問題
- Fixes #21 — 記事日付の表示がビルド環境のタイムゾーンに依存する問題
- Fixes #22 — proseテーブルの横スクロール不能・長語の折り返し防御なし
- Fixes #23 — 文字列画像パス・links.caseにwithBaseが適用されない潜在404
- Fixes #24 — featured記事がblog一覧に重複表示される問題
- Fixes #25 — robots.txt / _headers がGitHub Pagesで機能しないことを明記(docs)

各issueごとに個別コミットに分割しています。

## Test plan
- [x] `npm run check`（型チェック）が通る
- [x] `npm run build` が通る
- [x] `<title>`/`og:title` にサイト名が2回現れないことを確認
- [x] Footerに /privacy /terms リンクが存在しないことを確認
- [x] `features.blog: false` でビルドし、Header/Footer両方から /blog リンクが消えることを確認
- [x] `dist/rss.xml` のchannel linkが `https://kpab.github.io/astro-haze/` になることを確認
- [x] `TZ=America/Los_Angeles` / `TZ=UTC` で記事日付表示が一致することを確認
- [x] ブラウザで375px幅相当のビューポートにて、proseテーブルが独立して横スクロールし長いURLも折り返されることを確認
- [x] ルート相対パス画像（`/og-image.png`）が `base` 込みで出力されることを確認
- [x] blog一覧でfeatured記事がLatest Postsと重複しないことを確認