### PR TITLE
feat(content): strengthen schema validation and add per-image gallery alt

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,7 +257,8 @@ cover: '../../assets/images/projects/northstar-cover.webp'
 coverAlt: 'Northstar shown on desktop and mobile'
 images:
   - '../../assets/images/projects/northstar-search.webp'
-  - '../../assets/images/projects/northstar-mobile.webp'
+  - src: '../../assets/images/projects/northstar-mobile.webp'
+    alt: 'Northstar mobile view with the service directory open'
 tech:
   - Astro
   - TypeScript
@@ -275,23 +276,26 @@ duration: '16 weeks'
 Write the case study here.
 ```
 
-| Field          | Requirement                                                                            |
-| -------------- | -------------------------------------------------------------------------------------- |
-| `title`        | Required string                                                                        |
-| `summary`      | Required string                                                                        |
-| `description`  | Optional string                                                                        |
-| `cover`        | Required local image under `src/assets/` (relative path), optimized via `astro:assets` |
-| `coverAlt`     | Optional string                                                                        |
-| `images`       | Optional array of local images under `src/assets/` (relative paths)                    |
-| `tech`         | Required string array                                                                  |
-| `role`         | Required string                                                                        |
-| `year`         | Required number                                                                        |
-| `featured`     | Boolean; defaults to `false`                                                           |
-| `links.live`   | Optional valid URL                                                                     |
-| `links.github` | Optional valid URL                                                                     |
-| `links.case`   | Optional string path or URL                                                            |
-| `client`       | Optional string                                                                        |
-| `duration`     | Optional string                                                                        |
+| Field          | Requirement                                                                                                                                          |
+| -------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `title`        | Required string                                                                                                                                      |
+| `summary`      | Required string                                                                                                                                      |
+| `description`  | Optional string                                                                                                                                      |
+| `cover`        | Required local image under `src/assets/` (relative path), optimized via `astro:assets`                                                               |
+| `coverAlt`     | Optional string                                                                                                                                      |
+| `images`       | Optional array of local images under `src/assets/`; each entry is a relative path or `{ src, alt }`; `alt` is optional (a numbered one is generated) |
+| `tech`         | Required string array                                                                                                                                |
+| `role`         | Required string                                                                                                                                      |
+| `year`         | Required four-digit integer                                                                                                                          |
+| `featured`     | Boolean; defaults to `false`                                                                                                                         |
+| `links.live`   | Optional valid URL                                                                                                                                   |
+| `links.github` | Optional valid URL                                                                                                                                   |
+| `links.case`   | Optional URL (`http…`), root-relative path (`/…`), anchor (`#…`), or `mailto:`/`tel:` link                                                           |
+| `client`       | Optional string                                                                                                                                      |
+| `duration`     | Optional string                                                                                                                                      |
+
+A relative `links.case` is accepted too, but the browser resolves it against the project
+page (`/work/<slug>/`) rather than the site root, so prefer `/…` for an on-site case study.
 
 ### Landing-page data
 
@@ -326,7 +330,11 @@ The complete landing schema accepts these optional sections:
 | `finalCta`     | `{ title, description, button: { text, href } }`                                                                                 |
 
 Within `hero`, `title`, `subtitle`, `description`, and `cta.primary` are required.
-`cta.secondary` and `image` are optional.
+`cta.secondary` and `image` are optional. Image fields (`hero.image`, `features[].image`,
+`gallery[].src`, `testimonials[].avatar`) must be a URL (`http…`) or a path — either
+root-relative (`/…`, typically under `public/`) or relative to the page. Link fields
+(`cta.*.href`, `pricing[].cta.href`, `finalCta.button.href`) additionally accept anchors
+(`#…`) and `mailto:`/`tel:` links. Both reject other URL schemes such as `javascript:`.
 
 ---
 

--- a/src/components/portfolio/ProjectGallery.astro
+++ b/src/components/portfolio/ProjectGallery.astro
@@ -3,11 +3,18 @@ import type { ImageMetadata } from 'astro';
 import Picture from '@/components/ui/Picture.astro';
 
 export interface Props {
-  images: ImageMetadata[];
+  images: { src: ImageMetadata; alt?: string }[];
   title: string;
 }
 
 const { images, title } = Astro.props;
+
+// The schema normalizes both frontmatter forms to { src, alt? }; entries
+// without a custom alt fall back to a numbered one.
+const items = images.map((entry, index) => ({
+  src: entry.src,
+  alt: entry.alt ?? `${title} project view ${index + 1}`,
+}));
 ---
 
 {
@@ -19,7 +26,7 @@ const { images, title } = Astro.props;
       </div>
 
       <div class="gallery__grid">
-        {images.map((src, index) => (
+        {items.map((item, index) => (
           <figure
             class:list={[
               'gallery__item',
@@ -27,8 +34,8 @@ const { images, title } = Astro.props;
             ]}
           >
             <Picture
-              src={src}
-              alt={`${title} project view ${index + 1}`}
+              src={item.src}
+              alt={item.alt}
               widths={[400, 800, 1200]}
               sizes={
                 index % 3 === 0 ? '100vw' : '(min-width: 640px) 50vw, 100vw'

--- a/src/components/ui/Button.astro
+++ b/src/components/ui/Button.astro
@@ -1,4 +1,6 @@
 ---
+import { classifyHref } from '@/lib/url';
+
 export interface Props {
   href?: string;
   variant?: 'glass' | 'solid' | 'outline' | 'ghost';
@@ -27,7 +29,8 @@ const {
   ...rest
 } = Astro.props;
 
-const isExternal = external ?? href?.startsWith('http') ?? false;
+const isExternal =
+  external ?? (href ? classifyHref(href) === 'external' : false);
 
 // aria-label replaces the accessible name computed from child content, so
 // the visually-hidden "(opens in new tab)" span below would otherwise go

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -1,6 +1,31 @@
 import { defineCollection } from 'astro:content';
 import { glob } from 'astro/loaders';
 import { z } from 'zod';
+import { classifyHref } from '@/lib/url';
+
+// A blank value is never a usable URL: `href=""` reloads the page and `src=""`
+// re-requests it, both without a word of warning. Surrounding whitespace is
+// trimmed off rather than carried into the markup.
+const nonBlank = z.string().trim().min(1, { message: 'Must not be empty' });
+
+// Values rendered into `href`. Every shape withBase() can resolve is accepted —
+// URLs, root-relative and relative paths, anchors, mailto:/tel: — so the schema
+// never rejects content the renderer handles. Only scheme-based injection
+// (javascript:, data:, …) is turned away.
+const href = nonBlank.refine((v) => classifyHref(v) !== 'unsafe', {
+  message:
+    'Must be an http(s) URL, a path, an anchor (#…), or a mailto:/tel: link',
+});
+
+// Values rendered into `<img src>`. Anchors and mailto:/tel: can never resolve
+// to an image, so they are rejected on top of the href rules.
+const imageSrc = nonBlank.refine(
+  (v) => {
+    const kind = classifyHref(v);
+    return kind === 'external' || kind === 'absolute' || kind === 'relative';
+  },
+  { message: 'Must be an http(s) URL or a path to an image file' },
+);
 
 // Blog collection — Markdown content via the Content Layer glob loader.
 // `image()` runs hero images through astro:assets (AVIF/WebP + responsive
@@ -33,16 +58,31 @@ const projects = defineCollection({
       description: z.string().optional(),
       cover: image(),
       coverAlt: z.string().optional(),
-      images: z.array(image()).optional(),
+      // A bare path (alt is auto-generated) or { src, alt } for a custom alt.
+      // Both are normalized to { src, alt? } so every consumer sees one shape.
+      images: z
+        .array(
+          z.preprocess(
+            (v) => (typeof v === 'string' ? { src: v } : v),
+            z.object({ src: image(), alt: z.string().min(1).optional() }),
+          ),
+        )
+        .optional(),
       tech: z.array(z.string()),
       role: z.string(),
-      year: z.number(),
+      // Four digits — catches a mistyped magnitude without ruling out the
+      // retrospective work people legitimately list.
+      year: z
+        .number()
+        .int()
+        .min(1000, { message: 'Must be a four-digit year' })
+        .max(9999, { message: 'Must be a four-digit year' }),
       featured: z.boolean().default(false),
       links: z
         .object({
           live: z.url().optional(),
           github: z.url().optional(),
-          case: z.string().optional(),
+          case: href.optional(),
         })
         .optional(),
       client: z.string().optional(),
@@ -62,10 +102,10 @@ const landing = defineCollection({
       subtitle: z.string(),
       description: z.string(),
       cta: z.object({
-        primary: z.object({ text: z.string(), href: z.string() }),
-        secondary: z.object({ text: z.string(), href: z.string() }).optional(),
+        primary: z.object({ text: z.string(), href }),
+        secondary: z.object({ text: z.string(), href }).optional(),
       }),
-      image: z.string().optional(),
+      image: imageSrc.optional(),
     }),
     features: z
       .array(
@@ -73,7 +113,7 @@ const landing = defineCollection({
           title: z.string(),
           description: z.string(),
           icon: z.string().optional(),
-          image: z.string().optional(),
+          image: imageSrc.optional(),
         }),
       )
       .optional(),
@@ -95,15 +135,16 @@ const landing = defineCollection({
           description: z.string(),
           features: z.array(z.string()),
           highlighted: z.boolean().default(false),
-          cta: z.object({ text: z.string(), href: z.string() }),
+          cta: z.object({ text: z.string(), href }),
         }),
       )
       .optional(),
     gallery: z
       .array(
         z.object({
-          src: z.string(),
-          alt: z.string(),
+          src: imageSrc,
+          // Empty alt would silently demote a content image to decorative.
+          alt: z.string().min(1),
           caption: z.string().optional(),
         }),
       )
@@ -115,7 +156,7 @@ const landing = defineCollection({
           role: z.string(),
           company: z.string().optional(),
           content: z.string(),
-          avatar: z.string().optional(),
+          avatar: imageSrc.optional(),
           rating: z.number().min(1).max(5).optional(),
         }),
       )
@@ -127,7 +168,7 @@ const landing = defineCollection({
       .object({
         title: z.string(),
         description: z.string(),
-        button: z.object({ text: z.string(), href: z.string() }),
+        button: z.object({ text: z.string(), href }),
       })
       .optional(),
   }),

--- a/src/content/projects/afterlight-cultural-archive.md
+++ b/src/content/projects/afterlight-cultural-archive.md
@@ -5,9 +5,12 @@ description: 'Afterlight pairs a flexible editorial system with a spatial browsi
 cover: '../../assets/images/projects/afterlight-cover.webp'
 coverAlt: 'Afterlight archive showing an oral history beside collection photography'
 images:
-  - '../../assets/images/projects/afterlight-story.webp'
-  - '../../assets/images/projects/afterlight-map.webp'
-  - '../../assets/images/projects/afterlight-collection.webp'
+  - src: '../../assets/images/projects/afterlight-story.webp'
+    alt: 'Curated story view pairing an oral history transcript with archival photographs'
+  - src: '../../assets/images/projects/afterlight-map.webp'
+    alt: 'Geographic browsing view plotting collection records across a neighbourhood map'
+  - src: '../../assets/images/projects/afterlight-collection.webp'
+    alt: 'Open exploration grid showing connected records with provenance details'
 tech:
   - 'Astro'
   - 'TypeScript'

--- a/src/lib/url.ts
+++ b/src/lib/url.ts
@@ -7,17 +7,67 @@
 // and leaves external URLs, anchors and already-prefixed paths untouched.
 const BASE = import.meta.env.BASE_URL.replace(/\/$/, '');
 
+export type HrefKind =
+  | 'external' // http(s):// or //host — another origin
+  | 'contact' // mailto: / tel:
+  | 'anchor' // #section — the current document
+  | 'absolute' // /path — root-relative, needs the base prefix
+  | 'relative' // path — resolved by the browser against the current page
+  | 'unsafe'; // any other scheme (javascript:, data:, …)
+
+// Strip the leading/trailing C0 controls and spaces the URL parser discards
+// before it looks at a URL at all, so `'  javascript:…'` is still recognized as
+// a scheme rather than as a relative path that happens to start with a space.
+function trimUrl(path: string): string {
+  // Everything at or below U+0020 — the C0 range plus the space itself.
+  const stripped = (code: number) => code <= 0x20;
+  let start = 0;
+  let end = path.length;
+  while (start < end && stripped(path.charCodeAt(start))) start++;
+  while (end > start && stripped(path.charCodeAt(end - 1))) end--;
+  return path.slice(start, end);
+}
+
+// The URL scheme of `path`, or '' when it has none. A scheme ends at the first
+// colon and cannot contain a path separator, query, or fragment marker (so
+// `/a:b` is a path, not a scheme). Only tab/CR/LF are dropped before matching,
+// mirroring what the URL parser removes from anywhere inside its input: a href
+// of `java\tscript:alert(1)` still runs as javascript:, while an interior space
+// is kept, so `Notes 2024: draft.html` stays the relative path browsers read it
+// as.
+function schemeOf(path: string): string {
+  const colon = path.indexOf(':');
+  if (colon <= 0) return '';
+  const head = path.slice(0, colon);
+  if (/[/?#]/.test(head)) return '';
+  const scheme = head.replace(/[\t\n\r]/g, '').toLowerCase();
+  return /^[a-z][a-z0-9+.-]*$/.test(scheme) ? scheme : '';
+}
+
+// Single source of truth for what a href-like string points at, shared by
+// withBase() below and the content-collection validators, so validation and
+// rendering can never disagree about a value.
+export function classifyHref(path: string): HrefKind {
+  const value = trimUrl(path);
+  // Two leading slashes mean another origin. Browsers fold a backslash into a
+  // slash for http(s), so `/\host` and `\\host` leave the site like `//host` does.
+  if (/^[/\\]{2}/.test(value)) return 'external';
+  if (value.startsWith('#')) return 'anchor';
+  const scheme = schemeOf(value);
+  if (scheme === 'http' || scheme === 'https') return 'external';
+  if (scheme === 'mailto' || scheme === 'tel') return 'contact';
+  if (scheme) return 'unsafe';
+  return value.startsWith('/') ? 'absolute' : 'relative';
+}
+
 export function withBase(path: string): string {
   if (!path) return path;
-  // Absolute URL, protocol-relative, anchor, or mailto/tel — leave as-is.
-  if (
-    /^([a-z][a-z0-9+.-]*:)?\/\//i.test(path) ||
-    path.startsWith('#') ||
-    /^(mailto:|tel:)/i.test(path)
-  ) {
-    return path;
-  }
-  if (!path.startsWith('/')) return path; // relative path — leave
-  if (BASE && (path === BASE || path.startsWith(BASE + '/'))) return path; // already prefixed
-  return BASE + path;
+  // Only root-relative paths need the base prefix; everything else — external
+  // URLs, anchors, mailto/tel, relative paths — is already resolvable as-is.
+  if (classifyHref(path) !== 'absolute') return path;
+  // Prefix the same string the classifier saw, or surrounding whitespace would
+  // land in the middle of the emitted URL.
+  const value = trimUrl(path);
+  if (BASE && (value === BASE || value.startsWith(BASE + '/'))) return value; // already prefixed
+  return BASE + value;
 }

--- a/src/pages/work/[...slug].astro
+++ b/src/pages/work/[...slug].astro
@@ -10,7 +10,7 @@ import Button from '@/components/ui/Button.astro';
 import Picture from '@/components/ui/Picture.astro';
 import ProjectGallery from '@/components/portfolio/ProjectGallery.astro';
 import siteConfig from '@/site.config';
-import { withBase } from '@/lib/url';
+import { classifyHref, withBase } from '@/lib/url';
 
 export async function getStaticPaths() {
   const projects = await getCollection('projects');
@@ -39,7 +39,8 @@ const projectLinks = [
   project.data.links?.case && {
     label: 'Read case study',
     href: withBase(project.data.links.case),
-    external: false,
+    // Unlike the two links above, a case study may live on or off site.
+    external: classifyHref(project.data.links.case) === 'external',
   },
 ].filter((link): link is { label: string; href: string; external: boolean } =>
   Boolean(link),


### PR DESCRIPTION
Closes #48

## 概要

content collections の zod スキーマを強化し、ギャラリー画像に個別 alt を付けられるようにします。

- `src/lib/url.ts` に `classifyHref()` を追加し、href 文字列の分類（external / contact / anchor / absolute / relative / unsafe）を **`withBase()` とスキーマバリデータで共有**。レンダラが解決できる形式をバリデータが弾く、という食い違いが起きない構造にした
- その分類器を使って `links.case` と landing の href 系（`hero.cta.*.href` / `pricing[].cta.href` / `finalCta.button.href`）を検証。`withBase()` が扱える形式（URL / `/…` / 相対 / `#…` / `mailto:` / `tel:`）はすべて通し、**`javascript:` などのスキーム注入と空文字だけを弾く**
- 画像系（`hero.image` / `features[].image` / `gallery[].src` / `testimonials[].avatar`）には、画像として解決しえないアンカーと `mailto:`/`tel:` も追加で弾くバリデータを適用
- `projects.year` を `.int().min(1000).max(9999)` に強化。桁数を間違えた typo（`20226`）を弾きつつ、`1998` のような過去の実績は通す
- `projects.images` を `z.preprocess` で `{ src, alt? }` に正規化。文字列記法（`- 'path'`）とオブジェクト記法（`- src: … / alt: …`）の両方を受け付け、**消費側は常に単一の形**を見る
- `ProjectGallery.astro` は連番 alt のフォールバックのみを担当
- `[...slug].astro` の case リンクは `external: false` ハードコードをやめ、`classifyHref()` から導出。`Button.astro` の external 判定も同じ分類器に統一
- デモコンテンツ `afterlight-cultural-archive.md` をオブジェクト記法のサンプルに変更、README のフロントマター表・landing 節を更新

## issue 本文からの逸脱

| issue の記載 | 実装 | 理由 |
| --- | --- | --- |
| `images` は文字列配列 | `image()`（ImageMetadata）ベース | 現行実装がすでに `image()` 経由のため |
| `year` は `.min(2000).max(2100)` | `.min(1000).max(9999)` | `min(2000)` は 1998 年の実績を弾く一方、狙いの typo（`2062` ← `2026`）は素通りする。桁数チェックのほうが目的に合う |
| `startsWith('http') \|\| startsWith('/') \|\| startsWith('#')` 程度の緩い検証 | `classifyHref()` による分類 | 前者は `http-diagram.png` を URL 扱いし、正しい相対パス `shot.png` を弾く（判定が逆転する）。また `mailto:`/`tel:`/`//host` の扱いが `withBase()` と食い違う |
| `images` を union で後方互換 | `z.preprocess` で正規化 | `image()` は content layer では `z.string().transform()` でしかなく任意文字列を通す。リモート URL は `imageSrcToImportId` が `undefined` を返して生文字列のまま残るため、union だと消費側の `'alt' in entry` が TypeError になる |

## 破壊的変更について

フロントマターの契約は変わりません（`- 'path'` も `- { src, alt }` も通る）。変わるのは
`CollectionEntry<'projects'>['data']['images']` の型が
`(ImageMetadata)[]` → `{ src: ImageMetadata; alt?: string }[]` になる点のみで、テーマ内の消費者は
`ProjectGallery.astro` だけです。fork して `data.images` を直接触っている場合のみ影響します。

## 確認事項

- [x] 既存コンテンツが無変更でビルド可能（後方互換）— afterlight 以外の3件は文字列記法のまま
- [x] オブジェクト記法の images で個別 alt が出力される
- [x] 不正な year / `javascript:` の links.case はスキーマエラーになる
- [x] `npm run check`（astro check + tsc）/ `npm run lint` / `npm run format:check` すべて 0 エラー
- [x] `npx astro build` 成功
- [x] `classifyHref()` の分類を 29 ケースで確認（空白・制御文字混入、大文字スキーム、`data:`、`vbscript:`、`/\host`、コロン入りファイル名など）
- [x] 実ビルドでの回帰確認 — 通る: リモート URL の images / 相対 `links.case` / 相対 `hero.image` / `year: 1998`。弾かれる: `javascript:alert(1)`（前後空白つきも）/ `hero.image: '#top'` / 空文字・空白のみ / `alt: ''` / `year: 20226`
