### PR TITLE
feat(seo): full-text RSS feed and sitemap lastmod

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@
 | **Portfolio**         | Index with technology filters, case-study pages, and responsive galleries                      |
 | **Landing page**      | Config-driven hero, features, benefits, pricing, gallery, testimonials, FAQ & final CTA        |
 | **Content Layer**     | Astro 7 collections with Zod-validated frontmatter; Markdown **and** MDX (Sätteri engine)      |
-| **SEO & feeds**       | Canonical URLs, Open Graph, Twitter cards, JSON-LD, RSS feed & XML sitemap                     |
+| **SEO & feeds**       | Canonical URLs, Open Graph, Twitter cards, JSON-LD, full-text RSS & XML sitemap with `lastmod` |
 | **Accessible**        | Landmarks, skip nav, keyboard focus states, WCAG AA-conscious color & interaction              |
 | **Respectful motion** | Honors `prefers-reduced-motion` and `prefers-reduced-transparency`                             |
 | **Optimized images**  | AVIF/WebP with responsive `srcset` via `astro:assets`                                          |
@@ -165,6 +165,11 @@ visibility, social links, and page options.
 
 Header navigation entries and the sitemap integration respond to these flags. The `/rss.xml`
 feed and content routes are always part of the static build.
+
+The feed carries each post's full body in `<content:encoded>`, sanitized down to the tags a
+reader can render and with every image and link rewritten to an absolute URL. The sitemap
+gives blog entries a `<lastmod>` of `updatedDate ?? pubDate`; other routes carry none, since
+nothing in their frontmatter records when they changed.
 
 > [!TIP]
 > The search index is generated during `astro build`. In development the last built index

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,14 +1,64 @@
+import { readFileSync, readdirSync } from 'node:fs';
+import { join, relative } from 'node:path';
 import { defineConfig } from 'astro/config';
 import sitemap from '@astrojs/sitemap';
 import mdx from '@astrojs/mdx';
 import pagefind from 'astro-pagefind';
 import siteConfig from './src/site.config.ts';
 
+// Served from a GitHub Pages project site: https://kpab.github.io/astro-haze/
+const SITE = 'https://kpab.github.io';
+const BASE = '/astro-haze';
+const BLOG_DIR = 'src/content/blog';
+
+/** Every Markdown/MDX file under `dir`, as paths relative to it. */
+function listEntries(dir) {
+  return readdirSync(dir, { recursive: true, withFileTypes: true })
+    .filter((e) => e.isFile() && /\.mdx?$/.test(e.name))
+    .map((e) => relative(dir, join(e.parentPath, e.name)));
+}
+
+/** The value of a single frontmatter key, or undefined when it isn't set. */
+function frontmatterValue(source, key) {
+  const block = /^---\r?\n([\s\S]*?)\r?\n---/.exec(source);
+  if (!block) return undefined;
+  const match = new RegExp(`^${key}:\\s*(.+)$`, 'm').exec(block[1]);
+  return match?.[1].trim().replace(/^['"]|['"]$/g, '');
+}
+
+/**
+ * `lastmod` per blog URL, keyed by pathname.
+ *
+ * astro.config runs outside the Astro module graph, so `astro:content` — and
+ * with it the parsed collection — isn't importable here. The two date fields
+ * are read straight from the frontmatter instead; anything unparseable is
+ * skipped so a bad date costs that page its `lastmod` rather than the build.
+ *
+ * Projects deliberately get no entry: their schema carries `year` only, and a
+ * year is too coarse to claim as a modification timestamp.
+ */
+function blogLastmod() {
+  const prefix = `${BASE}/blog/`.replace(/\/+/g, '/');
+  const map = new Map();
+  for (const file of listEntries(BLOG_DIR)) {
+    const source = readFileSync(join(BLOG_DIR, file), 'utf8');
+    const raw =
+      frontmatterValue(source, 'updatedDate') ??
+      frontmatterValue(source, 'pubDate');
+    const date = raw ? new Date(raw) : undefined;
+    if (!date || Number.isNaN(date.valueOf())) continue;
+    const id = file.replace(/\.mdx?$/, '').replaceAll('\\', '/');
+    map.set(`${prefix}${id}/`, date.toISOString());
+  }
+  return map;
+}
+
+const LASTMOD = blogLastmod();
+
 // https://astro.build/config
 export default defineConfig({
-  // Served from a GitHub Pages project site: https://kpab.github.io/astro-haze/
-  site: 'https://kpab.github.io',
-  base: '/astro-haze',
+  site: SITE,
+  base: BASE,
   // MDX is always enabled so `.mdx` files in the content collections render
   // (the blog/projects globs already accept them). Sitemap and Pagefind are
   // gated by their `features` flags in site.config. Pagefind indexes the
@@ -16,7 +66,16 @@ export default defineConfig({
   // (run a build once to generate it).
   integrations: [
     mdx(),
-    ...(siteConfig.features.sitemap ? [sitemap()] : []),
+    ...(siteConfig.features.sitemap
+      ? [
+          sitemap({
+            serialize(item) {
+              const lastmod = LASTMOD.get(new URL(item.url).pathname);
+              return lastmod ? { ...item, lastmod } : item;
+            },
+          }),
+        ]
+      : []),
     ...(siteConfig.features.search ? [pagefind()] : []),
   ],
   output: 'static',

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,12 +14,14 @@
         "@astrojs/sitemap": "^3.7.3",
         "astro": "^7.2.1",
         "astro-pagefind": "^2.0.1",
+        "sanitize-html": "^2.17.7",
         "zod": "^4.4.3"
       },
       "devDependencies": {
         "@astrojs/check": "^0.9.10",
         "@eslint/js": "^9.39.5",
         "@types/node": "^26.2.0",
+        "@types/sanitize-html": "^2.16.1",
         "eslint": "^9.39.5",
         "eslint-plugin-astro": "^1.7.0",
         "eslint-plugin-jsx-a11y": "^6.10.2",
@@ -1383,6 +1385,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1405,6 +1408,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1424,6 +1428,7 @@
       "version": "0.35.3",
       "resolved": "https://registry.npmjs.org/@img/sharp-freebsd-wasm32/-/sharp-freebsd-wasm32-0.35.3.tgz",
       "integrity": "sha512-lUxcqWIj2wMQ9BrwNjngcr1gWUr5xgaGThBRqPPalIC2n67Cqj1uPh8NnA/ZhAg8hUbKl+kVHKwgUIwe6ZYPrg==",
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1446,6 +1451,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1462,6 +1468,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1478,6 +1485,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1494,6 +1502,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1510,6 +1519,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1526,6 +1536,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1542,6 +1553,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1558,6 +1570,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1574,6 +1587,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1590,6 +1604,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1606,6 +1621,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1628,6 +1644,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1650,6 +1667,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1672,6 +1690,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1694,6 +1713,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1716,6 +1736,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1738,6 +1759,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1760,6 +1782,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1779,6 +1802,7 @@
       "version": "0.35.3",
       "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.35.3.tgz",
       "integrity": "sha512-cZ0XkcYGpHZkqW6iCkqTcmUC0CD9DhD5d/qeZlZkfRBn6GnHniZXLUo5+9xw8Iv76YE6LQFN9YNBlKREcCG76w==",
+      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
       "optional": true,
       "dependencies": {
@@ -1798,6 +1822,7 @@
       "cpu": [
         "wasm32"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
@@ -1817,6 +1842,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1836,6 +1862,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1855,6 +1882,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2560,6 +2588,49 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~8.3.0"
+      }
+    },
+    "node_modules/@types/sanitize-html": {
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/@types/sanitize-html/-/sanitize-html-2.16.1.tgz",
+      "integrity": "sha512-n9wjs8bCOTyN/ynwD8s/nTcTreIHB1vf31vhLMGqUPNHaweKC4/fAl4Dj+hUlCTKYgm4P3k83fmiFfzkZ6sgMA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "htmlparser2": "^10.1"
+      }
+    },
+    "node_modules/@types/sanitize-html/node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/@types/sanitize-html/node_modules/htmlparser2": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.1.0.tgz",
+      "integrity": "sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.2.2",
+        "entities": "^7.0.1"
       }
     },
     "node_modules/@types/sax": {
@@ -3976,6 +4047,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/dayjs": {
+      "version": "1.11.21",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.21.tgz",
+      "integrity": "sha512-98IT+HOahAisibz/yjKbzuOBwYcjJ7BCLPzARyHiyEBmRz4fatF+KPJszEHXsGYjUG234aH/cOjW1wwTbKUZlA==",
+      "license": "MIT"
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -4012,6 +4089,15 @@
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/deepmerge": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+      "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/define-data-property": {
       "version": "1.1.4",
@@ -5759,6 +5845,107 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/htmlparser2": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-12.0.0.tgz",
+      "integrity": "sha512-Tz7u1i95/g2x2jz81+x0FBVhBhY5aRTvD3tXXdFaljuNdzDLJ8UGNRrTcj2cgQvAg3iW/h77Fz15nLW0L0CrZw==",
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^3.0.0",
+        "domhandler": "^6.0.0",
+        "domutils": "^4.0.2",
+        "entities": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/htmlparser2/node_modules/dom-serializer": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-3.1.1.tgz",
+      "integrity": "sha512-4MEa38/QexBob6gFNwu+EGdWvhJ1OKuNwdYY3Y3NyeWDQfnGeDYQUDfIRzWu5B5gsv03so2Uxd28YC6zrsx3Lw==",
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^3.0.0",
+        "domhandler": "^6.0.0",
+        "entities": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/htmlparser2/node_modules/domelementtype": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-3.0.0.tgz",
+      "integrity": "sha512-umCQid3jKbDmVjx8jGaW7uUykm4DEUeyV21hPxNMo2nV955DhUThwqyOIDtreepP31hl84X7G5U9ZfsWvIB3Pg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/htmlparser2/node_modules/domhandler": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-6.0.1.tgz",
+      "integrity": "sha512-gYzvtM72ZtxQO0T048kd6HWSbbGCNOUwcnfQ01cqIJ4X2IYKFFHZ5mKvrQETcFXxsRObZulDaKmy//R7TPtsBg==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "domelementtype": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/htmlparser2/node_modules/domutils": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-4.0.2.tgz",
+      "integrity": "sha512-qI4JLRKnSzqFqr7hAlS5xQDusBCjKSEG4t4+7aNrIQMHBcsC2TGEhuyABJdYkgSewL57PNLYEiibY2iPKhKpaA==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dom-serializer": "^3.0.0",
+        "domelementtype": "^3.0.0",
+        "domhandler": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
+    "node_modules/htmlparser2/node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
     "node_modules/http-cache-semantics": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
@@ -6150,6 +6337,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-plain-object": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+      "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/is-regex": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
@@ -6424,6 +6620,15 @@
       },
       "engines": {
         "node": ">=0.10"
+      }
+    },
+    "node_modules/launder": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/launder/-/launder-1.7.1.tgz",
+      "integrity": "sha512-mU6WRz5EusL9ZZuiZ5SO4Y6C0P9PAUR9iwdb6bzj4KDihm28DiHFw+/yk9DBH4f+Pv1wuzQ4e2jV3oQ7mkIqvw==",
+      "license": "MIT",
+      "dependencies": {
+        "dayjs": "^1.11.7"
       }
     },
     "node_modules/levn": {
@@ -8294,6 +8499,12 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/parse-srcset": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/parse-srcset/-/parse-srcset-1.0.2.tgz",
+      "integrity": "sha512-/2qh0lav6CmI15FzA3i/2Bzk2zCgQhGMkvhOhKNcBVQ1ldgpbfiNTVslmooUmWJcADi1f1kIeynbDRVzNlfR6Q==",
+      "license": "MIT"
+    },
     "node_modules/parse5": {
       "version": "7.3.0",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
@@ -9044,6 +9255,36 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/sanitize-html": {
+      "version": "2.17.7",
+      "resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-2.17.7.tgz",
+      "integrity": "sha512-PGtEkc9cbnedU3s9TmzDbpsZ8w086g/0Q8k8/oIO1NLNU3i5k9yn835CrjJSajp1KMmkisbO1qPXxNKO3welAg==",
+      "license": "MIT",
+      "dependencies": {
+        "deepmerge": "^4.2.2",
+        "escape-string-regexp": "^4.0.0",
+        "htmlparser2": "^12.0.0",
+        "is-plain-object": "^5.0.0",
+        "launder": "^1.7.1",
+        "parse-srcset": "^1.0.2",
+        "postcss": "^8.3.11"
+      },
+      "engines": {
+        "node": ">=22.12.0"
+      }
+    },
+    "node_modules/sanitize-html/node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/sass-formatter": {

--- a/package.json
+++ b/package.json
@@ -21,12 +21,14 @@
     "@astrojs/sitemap": "^3.7.3",
     "astro": "^7.2.1",
     "astro-pagefind": "^2.0.1",
+    "sanitize-html": "^2.17.7",
     "zod": "^4.4.3"
   },
   "devDependencies": {
     "@astrojs/check": "^0.9.10",
     "@eslint/js": "^9.39.5",
     "@types/node": "^26.2.0",
+    "@types/sanitize-html": "^2.16.1",
     "eslint": "^9.39.5",
     "eslint-plugin-astro": "^1.7.0",
     "eslint-plugin-jsx-a11y": "^6.10.2",

--- a/src/pages/rss.xml.ts
+++ b/src/pages/rss.xml.ts
@@ -1,8 +1,107 @@
 import rss from '@astrojs/rss';
 import type { APIContext } from 'astro';
+import { experimental_AstroContainer as AstroContainer } from 'astro/container';
+import { render } from 'astro:content';
+import sanitizeHtml from 'sanitize-html';
 import { getPublishedPosts } from '@/lib/posts';
 import { withBase } from '@/lib/url';
 import siteConfig, { resolvedOgLocale } from '@/site.config';
+
+// Tags a feed reader can be expected to render. Everything outside this list is
+// dropped: <script>/<style> because a feed is untrusted input downstream, and
+// Astro's own wrappers because they carry no meaning outside the page.
+const ALLOWED_TAGS = [
+  'p',
+  'br',
+  'hr',
+  'h2',
+  'h3',
+  'h4',
+  'h5',
+  'h6',
+  'strong',
+  'em',
+  'del',
+  'sub',
+  'sup',
+  'blockquote',
+  'ul',
+  'ol',
+  'li',
+  'a',
+  'img',
+  'figure',
+  'figcaption',
+  'picture',
+  'source',
+  'pre',
+  'code',
+  'table',
+  'thead',
+  'tbody',
+  'tr',
+  'th',
+  'td',
+  'section',
+];
+
+const ALLOWED_ATTRIBUTES: sanitizeHtml.IOptions['allowedAttributes'] = {
+  a: ['href', 'title'],
+  img: ['src', 'alt', 'title', 'width', 'height', 'srcset', 'sizes'],
+  source: ['srcset', 'sizes', 'type'],
+  th: ['colspan', 'rowspan', 'scope'],
+  td: ['colspan', 'rowspan'],
+  code: ['class'], // language-* survives so readers can highlight
+};
+
+/**
+ * Resolve a URL found in post HTML against the feed's own origin.
+ *
+ * A feed item is read outside the site, so a root-relative `/astro-haze/…` or a
+ * document-relative `./diagram.png` resolves against whatever host the reader
+ * is on. Anchors are dropped entirely rather than made absolute: an in-page
+ * `#heading` link points at the article page, not at the feed entry.
+ */
+function absolutize(value: string, base: URL): string | undefined {
+  if (value.startsWith('#')) return undefined;
+  try {
+    return new URL(value, base).href;
+  } catch {
+    return undefined;
+  }
+}
+
+/** Rewrite the URL-bearing attributes of one tag to absolute form. */
+function absolutizeAttributes(
+  attribs: Record<string, string>,
+  base: URL,
+): Record<string, string> {
+  const next = { ...attribs };
+  for (const key of ['href', 'src'] as const) {
+    const raw = next[key];
+    if (!raw) continue;
+    const resolved = absolutize(raw, base);
+    if (resolved) next[key] = resolved;
+    else delete next[key];
+  }
+  // srcset is a comma-separated list of "url descriptor" pairs.
+  for (const key of ['srcset'] as const) {
+    const raw = next[key];
+    if (!raw) continue;
+    const rewritten = raw
+      .split(',')
+      .map((candidate) => {
+        const [url, ...descriptors] = candidate.trim().split(/\s+/);
+        if (!url) return undefined;
+        const resolved = absolutize(url, base);
+        return resolved ? [resolved, ...descriptors].join(' ') : undefined;
+      })
+      .filter((candidate): candidate is string => Boolean(candidate));
+    if (rewritten.length) next[key] = rewritten.join(', ');
+    else delete next[key];
+  }
+  return next;
+}
 
 export async function GET(context: APIContext) {
   const posts = await getPublishedPosts();
@@ -13,19 +112,46 @@ export async function GET(context: APIContext) {
   const site = context.site
     ? new URL(import.meta.env.BASE_URL, context.site)
     : siteConfig.url;
+  const siteUrl = new URL(site);
+
+  // The stored `rendered.html` still holds astro:assets placeholders for images
+  // in the body, so rendering the entry's Content component is what produces
+  // the same optimized markup the page itself serves.
+  const container = await AstroContainer.create();
+
+  const items = await Promise.all(
+    posts.map(async (post) => {
+      const link = withBase(`/blog/${post.id}/`);
+      const { Content } = await render(post);
+      const html = await container.renderToString(Content);
+      const base = new URL(link, siteUrl);
+
+      return {
+        title: post.data.title,
+        description: post.data.description,
+        pubDate: post.data.pubDate,
+        link,
+        categories: post.data.tags,
+        author: post.data.author,
+        content: sanitizeHtml(html, {
+          allowedTags: ALLOWED_TAGS,
+          allowedAttributes: ALLOWED_ATTRIBUTES,
+          transformTags: {
+            '*': (tagName, attribs) => ({
+              tagName,
+              attribs: absolutizeAttributes(attribs, base),
+            }),
+          },
+        }),
+      };
+    }),
+  );
 
   return rss({
     title: `${siteConfig.name} — Blog`,
     description: siteConfig.description,
     site,
-    items: posts.map((post) => ({
-      title: post.data.title,
-      description: post.data.description,
-      pubDate: post.data.pubDate,
-      link: withBase(`/blog/${post.id}/`),
-      categories: post.data.tags,
-      author: post.data.author,
-    })),
+    items,
     customData: `<language>${resolvedOgLocale.toLowerCase().replace('_', '-')}</language>`,
   });
 }


### PR DESCRIPTION
Closes #46

## 概要

- **RSS 全文配信**: 各 item に `<content:encoded>` で本文を出力。HTML はコンテナ API で `Content` コンポーネントをレンダリングして取得し、`sanitize-html` を通したうえで `href` / `src` / `srcset` をすべて絶対 URL に書き換え
- **sitemap `lastmod`**: blog の各記事に `updatedDate ?? pubDate` を付与
- `<language>` タグは既存実装で出力済みだったため変更なし

## 実装上の判断

**`rendered.html` ではなくコンテナ API を使った理由**

content layer の `entry.rendered.html` は本文画像が `__ASTRO_IMAGE_` プレースホルダのまま格納されており（実体の解決は `render()` 時の `updateImageReferencesInBody`）、そのまま流すとフィードの画像が壊れます。`render(post)` → `container.renderToString(Content)` にすることで、ページが配信しているのと同じ最適化済み `<img>` が得られます。

**アンカーリンクは `href` ごと削除**

`#heading` はフィードリーダー上では意味を持たない（記事ページ内の位置を指す）ため、絶対 URL 化せず属性を落としています。

**`sanitize-html` の追加**

CONTRIBUTING の「新しい依存には強い理由が必要」に対して: フィードの HTML はリーダー側で untrusted input として扱われる領域で、HTML サニタイザの自作は避けるべき領域です。@astrojs/rss のドキュメントもこの構成を推奨しています。実サイズは 100KB、推移的依存の増加もありません。ビルド時のみ使用（`output: 'static'`）ですが、`npm ci --omit=dev && npm run build` を壊さないよう `dependencies` に置いています。

**sitemap の日付をフロントマターから直接読んでいる理由**

`astro.config.mjs` は Astro のモジュールグラフの外で動くため `astro:content` を import できず、パース済みコレクションに到達できません。フロントマターの2フィールドのみを読み出す実装にし、日付がパースできない場合はそのページの `lastmod` を落とすだけでビルドは通す、という縮退にしています。

**projects に `lastmod` を付けていない理由**

projects のスキーマは `year` しか持たず、年単位では更新時刻として粗すぎるためです。付けるなら `updatedDate` をスキーマに足す別issueが必要です。

## 検証

- `npm run check`（astro check + tsc）0 エラー / `npm run lint` 0 / `npm run format:check` OK / `npx astro build` 成功
- `dist/rss.xml`: XML well-formed、`xmlns:content` 宣言あり、2記事とも `<content:encoded>` に本文。channel の title / link / description 揃い、`<language>en-us>` 出力
- **URL 書き換えを一時記事で実測**（検証後に削除）:

| 記述 | フィード出力 |
| --- | --- |
| `![A diagram](../../assets/…jpg)` | `src="https://kpab.github.io/astro-haze/_astro/getting-started.…webp"`（最適化済み・絶対） |
| `[a sibling post](getting-started/)` | `https://kpab.github.io/astro-haze/blog/<slug>/getting-started/` |
| `[anchor](#heading-…)` | `<a>`（href 削除） |
| `[external](https://example.com/x)` | 不変 |

- `dist/sitemap-0.xml`: 18 URL 中、blog 記事2件に `<lastmod>`。`updatedDate: 2026-03-09` を一時的に足して**優先順位も実測**（`pubDate: 2024-01-15` → `2026-03-09T00:00:00.000Z` に変わることを確認、検証後に revert）
- blog インデックスや work 詳細に `lastmod` が付かないことも確認

## 別件（このPRでは触っていない）

検証中に判明: **Markdown 本文内のルート相対リンク（`[x](/work/)`）が base を無視する**。ページ側も `<a href="/work/">` を出力しており、project site（`/astro-haze/`）では 404 になります。フィードは**ページと同じ解決結果**を出すようにしてある（勝手に直すとページとフィードで飛び先が変わるため）ので、このPRでの挙動は意図どおりです。根本修正は別issueとして切る必要があります。
