### PR TITLE
fix(markdown): apply the base path to root-relative body links

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,11 @@ Collection definitions and validation rules live in
 [`src/content.config.ts`](src/content.config.ts). Astro reports invalid or missing fields
 during development and builds.
 
+Links and images written in a Markdown body may use a root-relative path (`/work/`): the
+configured `base` is applied to them at build time, so they keep working on a project site
+served from a subpath. Raw HTML blocks inside `.md`, and JSX elements inside `.mdx`, are
+passed through untouched — use a relative path or the full URL there.
+
 ### Blog posts
 
 Add `.md` or `.mdx` files to `src/content/blog/`:

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -5,6 +5,8 @@ import sitemap from '@astrojs/sitemap';
 import mdx from '@astrojs/mdx';
 import pagefind from 'astro-pagefind';
 import siteConfig from './src/site.config.ts';
+import { satteri } from '@astrojs/markdown-satteri';
+import satteriBaseUrls from './src/lib/satteri-base-urls.ts';
 
 // Served from a GitHub Pages project site: https://kpab.github.io/astro-haze/
 const SITE = 'https://kpab.github.io';
@@ -99,7 +101,14 @@ export default defineConfig({
     format: ['avif', 'webp'],
   },
   // Markdown is handled by Sätteri (Astro 7 default). GFM — tables, task
-  // lists, footnotes — is enabled out of the box, so no config is needed.
+  // lists, footnotes — is on out of the box, so the processor is named here
+  // only to extend its hast pass with the plugin that applies `base` to
+  // root-relative URLs an author writes in a body, which Astro otherwise
+  // passes through untouched. MDX inherits this config, so `.mdx` bodies get
+  // the same treatment.
+  markdown: {
+    processor: satteri({ hastPlugins: [satteriBaseUrls(BASE)] }),
+  },
   server: {
     port: 3000,
     host: true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.2.1",
       "license": "MIT",
       "dependencies": {
+        "@astrojs/markdown-satteri": "0.3.5",
         "@astrojs/mdx": "^7.0.5",
         "@astrojs/rss": "^4.0.19",
         "@astrojs/sitemap": "^3.7.3",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "node": ">=22.12"
   },
   "dependencies": {
+    "@astrojs/markdown-satteri": "0.3.5",
     "@astrojs/mdx": "^7.0.5",
     "@astrojs/rss": "^4.0.19",
     "@astrojs/sitemap": "^3.7.3",

--- a/src/lib/satteri-base-urls.ts
+++ b/src/lib/satteri-base-urls.ts
@@ -1,0 +1,62 @@
+import type { HastPluginDefinition } from 'satteri';
+import { classifyHref, withBaseOf } from './url';
+
+// Attributes that hold a single URL. Markdown itself only produces `a[href]`
+// and `img[src]`; the rest cover elements an MDX body can render directly.
+//
+// Multi-URL attributes (`srcset`) are deliberately left alone: they only appear
+// in hand-written markup, and a half-rewritten candidate list is worse than an
+// untouched one.
+const URL_ATTRIBUTES: Record<string, readonly string[]> = {
+  a: ['href'],
+  area: ['href'],
+  audio: ['src'],
+  embed: ['src'],
+  iframe: ['src'],
+  img: ['src'],
+  object: ['data'],
+  source: ['src'],
+  track: ['src'],
+  video: ['src', 'poster'],
+};
+
+/**
+ * Prefix root-relative URLs in Markdown bodies with the configured base.
+ *
+ * Astro applies `base` to imported assets and `Astro.url`, but not to a URL an
+ * author types into a body. On a project site — say `/astro-haze/` —
+ * `[archive](/work/)` therefore renders as `href="/work/"`, which resolves
+ * against the origin root and 404s.
+ *
+ * Only root-relative values are touched. External URLs, relative paths, anchors
+ * and `mailto:` links are left exactly as written, and the prefixing is
+ * idempotent, so an already-prefixed path passes through unchanged. The
+ * classification comes from `classifyHref()` — the same function `withBase()`
+ * and the content-collection validators use — so a URL cannot be judged one way
+ * here and another way at render time.
+ *
+ * The base is a parameter rather than `import.meta.env.BASE_URL`: this plugin is
+ * constructed from `astro.config`, which sits outside the app's module graph,
+ * where that value is still the default `/`.
+ *
+ * Raw HTML blocks in `.md` are left alone — Sätteri keeps them as raw nodes
+ * instead of parsing them into elements, so no attribute is ever visited there.
+ */
+export default function satteriBaseUrls(base: string): HastPluginDefinition {
+  return {
+    name: 'astro-haze:base-urls',
+    element: {
+      filter: Object.keys(URL_ATTRIBUTES),
+      visit(node, ctx) {
+        const attributes = URL_ATTRIBUTES[node.tagName];
+        if (!attributes) return;
+        for (const attribute of attributes) {
+          const value = node.properties?.[attribute];
+          if (typeof value !== 'string') continue;
+          if (classifyHref(value) !== 'absolute') continue;
+          ctx.setProperty(node, attribute, withBaseOf(base, value));
+        }
+      },
+    },
+  };
+}

--- a/src/lib/url.ts
+++ b/src/lib/url.ts
@@ -5,7 +5,6 @@
 // Astro auto-prefixes imported assets (astro:assets) and Astro.url, but NOT
 // hardcoded href/src strings, so those go through withBase(). It is idempotent
 // and leaves external URLs, anchors and already-prefixed paths untouched.
-const BASE = import.meta.env.BASE_URL.replace(/\/$/, '');
 
 export type HrefKind =
   | 'external' // http(s):// or //host — another origin
@@ -60,14 +59,29 @@ export function classifyHref(path: string): HrefKind {
   return value.startsWith('/') ? 'absolute' : 'relative';
 }
 
-export function withBase(path: string): string {
+/**
+ * withBase() against an explicitly supplied base.
+ *
+ * Code that runs from `astro.config` — a Markdown plugin, say — sits outside
+ * the app's module graph, where `import.meta.env.BASE_URL` is still the default
+ * `/` rather than the configured base. Such callers pass the base in; everyone
+ * inside the app should use withBase() below.
+ */
+export function withBaseOf(base: string, path: string): string {
   if (!path) return path;
   // Only root-relative paths need the base prefix; everything else — external
   // URLs, anchors, mailto/tel, relative paths — is already resolvable as-is.
   if (classifyHref(path) !== 'absolute') return path;
+  const prefix = base.replace(/\/$/, '');
   // Prefix the same string the classifier saw, or surrounding whitespace would
   // land in the middle of the emitted URL.
   const value = trimUrl(path);
-  if (BASE && (value === BASE || value.startsWith(BASE + '/'))) return value; // already prefixed
-  return BASE + value;
+  if (prefix && (value === prefix || value.startsWith(prefix + '/'))) {
+    return value; // already prefixed
+  }
+  return prefix + value;
+}
+
+export function withBase(path: string): string {
+  return withBaseOf(import.meta.env.BASE_URL, path);
 }

--- a/src/pages/rss.xml.ts
+++ b/src/pages/rss.xml.ts
@@ -1,7 +1,9 @@
 import rss from '@astrojs/rss';
 import type { APIContext } from 'astro';
 import { experimental_AstroContainer as AstroContainer } from 'astro/container';
+import { loadRenderers } from 'astro:container';
 import { render } from 'astro:content';
+import { getContainerRenderer as mdxContainerRenderer } from '@astrojs/mdx/container-renderer';
 import sanitizeHtml from 'sanitize-html';
 import { getPublishedPosts } from '@/lib/posts';
 import { withBase } from '@/lib/url';
@@ -117,7 +119,13 @@ export async function GET(context: APIContext) {
   // The stored `rendered.html` still holds astro:assets placeholders for images
   // in the body, so rendering the entry's Content component is what produces
   // the same optimized markup the page itself serves.
-  const container = await AstroContainer.create();
+  //
+  // The MDX renderer has to be handed over explicitly: a bare container knows
+  // how to render `.md` but throws NoMatchingRenderer on the first `.mdx` post,
+  // and the blog glob accepts both.
+  const container = await AstroContainer.create({
+    renderers: await loadRenderers([mdxContainerRenderer()]),
+  });
 
   const items = await Promise.all(
     posts.map(async (post) => {


### PR DESCRIPTION
Closes #71

## 概要

Markdown 本文のルート相対リンク・画像に `base` を適用します。あわせて、検証中に判明した **`/rss.xml` の MDX クラッシュ**（#69 で入れた回帰）も修正しています。

## issue の方針からの変更

issue には「rehype プラグイン」と書きましたが、**Astro 7 では成立しませんでした**。

`markdown.rehypePlugins` は非推奨で、使うと `@astrojs/markdown-remark` のインストールを要求されます。

```
`markdown.rehypePlugins` … run on the `unified` processor from `@astrojs/markdown-remark`,
which is no longer installed by default now that Sätteri is the default Markdown processor.
```

これは unified 処理系への切り替えを意味し、README が明記している「Markdown は Sätteri（Astro 7 既定）」を覆します。そこで **Sätteri の hast プラグイン API** を使いました。

```js
markdown: {
  processor: satteri({ hastPlugins: [satteriBaseUrls(BASE)] }),
}
```

`@astrojs/markdown-satteri` は astro と @astrojs/mdx の推移的依存として既にツリーにあるため、**インストールサイズの増加はゼロ**です（直接 import する以上、package.json に明示しました）。

## 実装上の落とし穴（重要）

**プラグイン側では `import.meta.env.BASE_URL` が `"/"` になります。**

`astro.config` はアプリのモジュールグラフの外で評価されるため、`src/lib/url.ts` を import しても `BASE_URL` は既定値のままです。最初 `withBase()` をそのまま呼んでいて、**プラグインは走るのに何も書き換わらない**という状態になりました。

対策として `withBaseOf(base, path)` を切り出し、`withBase()` はそれを `import.meta.env.BASE_URL` で呼ぶだけにしています。プレフィックス規則の実装は 1 か所のままで、config 側だけ base を明示的に渡します。

判定は従来どおり `classifyHref()` に委ねているので、バリデータ・レンダラ・このプラグインの 3 者で解釈がずれることはありません。

## 対象外（ドキュメント済み）

- **`.md` 内の生 HTML** — Sätteri は raw ノードとして保持し element に展開しないため、属性が訪問されません
- **`.mdx` 内の JSX** — `mdxJsxElement` であって `element` ではありません

どちらもページとフィードで挙動が一致するため、書き換えないほうが安全です。README に「相対パスかフル URL を使う」と明記しました。

## 検証

`base: '/astro-haze'` での実測（一時記事、検証後に削除）:

| 記述 | 出力 | |
| --- | --- | --- |
| `[archive](/work/)` | `/astro-haze/work/` | ✅ 付与 |
| `[again](/astro-haze/work/)` | `/astro-haze/work/` | ✅ 冪等 |
| `[sibling](getting-started/)` | `getting-started/` | ✅ 不変 |
| `[heading](#heading)` | `#heading` | ✅ 不変 |
| `[x](https://example.com/x)` | 不変 | ✅ |
| `[mail](mailto:a@b.com)` | 不変 | ✅ |
| `[cdn](//cdn.example/x)` | 不変 | ✅ |
| `![](../../assets/…jpg)` | `/astro-haze/_astro/….webp` | ✅ 既存どおり |

- **`base: '/'` でも実測** — ルート相対リンクは一切変更されず、二重付与なし
- **MDX 本文の Markdown リンクも書き換わる**ことを確認（JSX 要素は対象外、想定どおり）
- **RSS フィードも自動追従** — `https://kpab.github.io/astro-haze/work/` を出力。#69 で「ページと同じ解決結果を出す」設計にしておいたため、ページ側を直すだけでフィードが正しくなりました
- `npm run check` 0エラー / `npm run lint` 0 / `npm run format:check` OK / `npx astro build` 成功

> [!NOTE]
> レンダリング済み Markdown は `node_modules/.astro` にキャッシュされます。プラグインを変更したのに出力が変わらない場合は `rm -rf .astro node_modules/.astro` してください（検証中にこれで 1 回騙されました）。

## 同梱した別修正: `/rss.xml` の MDX クラッシュ

検証用に `.mdx` 記事を置いた時点でビルドが落ちました。

```
[ERROR] [build] Caught error rendering /rss.xml: NoMatchingRenderer: Unable to render `Content`.
```

#69 で入れたコンテナ API は既定で `.md` しか描画できず、**`.mdx` 記事が 1 本でもあると `/rss.xml` ルートごと落ちます**。blog の glob は両方を受け付けるため、テーマ利用者が MDX で記事を書いた瞬間にフィードが失われる状態でした。デモ記事が全て `.md` だったので #69 では気づけていません。

`loadRenderers([mdxContainerRenderer()])` をコンテナに渡して修正し、MDX 記事が `<content:encoded>` に正しく出力されることを確認しました（4 items / 4 content）。
