### PR TITLE
refactor(landing): drop the image fields nothing renders

### DIFF
--- a/README.md
+++ b/README.md
@@ -331,20 +331,24 @@ The complete landing schema accepts these optional sections:
 
 | Section        | Shape                                                                                                                            |
 | -------------- | -------------------------------------------------------------------------------------------------------------------------------- |
-| `features`     | Array of `{ title, description, icon?, image? }`                                                                                 |
+| `features`     | Array of `{ title, description, icon? }`                                                                                         |
 | `benefits`     | Array of `{ title, description, icon? }`                                                                                         |
 | `pricing`      | Array of `{ name, price, period?, description, features, highlighted?, cta: { text, href } }`; `highlighted` defaults to `false` |
 | `gallery`      | Array of `{ src, alt, caption? }`                                                                                                |
-| `testimonials` | Array of `{ name, role, company?, content, avatar?, rating? }`; rating must be from 1 to 5                                       |
+| `testimonials` | Array of `{ name, role, company?, content, rating? }`; rating must be from 1 to 5                                                |
 | `faq`          | Array of `{ question, answer }`                                                                                                  |
 | `finalCta`     | `{ title, description, button: { text, href } }`                                                                                 |
 
 Within `hero`, `title`, `subtitle`, `description`, and `cta.primary` are required.
-`cta.secondary` and `image` are optional. Image fields (`hero.image`, `features[].image`,
-`gallery[].src`, `testimonials[].avatar`) must be a URL (`http…`) or a path — either
-root-relative (`/…`, typically under `public/`) or relative to the page. Link fields
-(`cta.*.href`, `pricing[].cta.href`, `finalCta.button.href`) additionally accept anchors
-(`#…`) and `mailto:`/`tel:` links. Both reject other URL schemes such as `javascript:`.
+`cta.secondary` and `image` are optional. Image fields (`hero.image`, `gallery[].src`) must
+be a URL (`http…`) or a path — either root-relative (`/…`, typically under `public/`) or
+relative to the page. Link fields (`cta.*.href`, `pricing[].cta.href`,
+`finalCta.button.href`) additionally accept anchors (`#…`) and `mailto:`/`tel:` links. Both
+reject other URL schemes such as `javascript:`.
+
+Feature cards are identified by a number and the `icon` glyph, and testimonials by the
+speaker's initials, so neither section takes an image. Adding one later is an additive
+change: a new optional field costs existing content nothing.
 
 ---
 

--- a/src/components/landing/Features.astro
+++ b/src/components/landing/Features.astro
@@ -7,7 +7,6 @@ export interface Props {
     title: string;
     description: string;
     icon?: string;
-    image?: string;
   }>;
 }
 

--- a/src/components/landing/Testimonials.astro
+++ b/src/components/landing/Testimonials.astro
@@ -7,7 +7,6 @@ export interface Props {
     role: string;
     company?: string;
     content: string;
-    avatar?: string;
     rating?: number;
   }>;
 }

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -113,7 +113,6 @@ const landing = defineCollection({
           title: z.string(),
           description: z.string(),
           icon: z.string().optional(),
-          image: imageSrc.optional(),
         }),
       )
       .optional(),
@@ -156,7 +155,6 @@ const landing = defineCollection({
           role: z.string(),
           company: z.string().optional(),
           content: z.string(),
-          avatar: imageSrc.optional(),
           rating: z.number().min(1).max(5).optional(),
         }),
       )


### PR DESCRIPTION
Closes #64

issue の **方針 B（スキーマから外す）** で対応しました。

## 背景

`features[].image` と `testimonials[].avatar` はスキーマにも両コンポーネントの Props にも宣言されていましたが、**どこにもレンダリングされていません**。フィーチャーカードは番号 + `icon` グリフ、証言はスピーカーのイニシャル円で構成されており、画像を差し込む場所がありません。

つまり作者がこれらのフィールドを書くと、**バリデーションは通るのに画面には何も出ない**という状態でした。PR #63 でバリデーション対象に含めたことで、この矛盾がより見えやすくなっていました。

## なぜ A（描画する）ではなく B か

- 現行デザインは番号 + グリフ / イニシャル円で完結していて、画像を足すと視覚的アイデンティティが変わります。「未実装」ではなく「そういうデザイン」に見える状態です
- A を選ぶと `alt` の扱い（装飾か内容か）、カード高さのアスペクト比固定、デモコンテンツ追加、両カラーモード × モバイルの視覚 QA まで必要になります
- **B は非破壊で、後から A に進むのも非破壊**です。逆順（先に描画を足して後で外す）は破壊的になるので、B → 必要になったら A、が手戻りのない順序です

## 後方互換性（実測）

zod は既定で未知キーを落とすため、既存の landing コンテンツに `image:` / `avatar:` が残っていても**ビルドは通ります**。

`demo.json` に一時的に両フィールドを足して検証（検証後 revert）:

- `npx astro build` 成功、`InvalidContentEntryDataError` なし
- 出力 HTML に値が漏れ出していないことも確認（grep 0 件）

## 検証

- `npm run check` 0エラー / `npm run lint` 0 / `npm run format:check` OK / `npx astro build` 成功
- ランディングページの描画に変化なし: フィーチャーカード 3 / 証言 3 / hero 画像あり / ギャラリー画像 3
- `imageSrc` バリデータは `hero.image` と `gallery[].src` で引き続き使用中

## README

セクション表から両フィールドを削除し、画像フィールドの説明を `hero.image` / `gallery[].src` のみに更新。あわせて「なぜ画像を取らないのか」と「後から足すのは非破壊」であることを明記しました。