### PR TITLE
feat(styles): container queries, fluid spacing and blur tokens

### DIFF
--- a/src/components/blog/PostGrid.astro
+++ b/src/components/blog/PostGrid.astro
@@ -16,39 +16,51 @@ const { posts, columns = 'auto' } = Astro.props;
 const showReadingTime = siteConfig.blog.showReadingTime;
 ---
 
-<div class={`posts-grid posts-grid--${columns}`}>
-  {
-    posts.map((post) => (
-      <BlogCard
-        title={post.data.title}
-        description={post.data.description}
-        pubDate={post.data.pubDate}
-        heroImage={post.data.heroImage}
-        heroImageAlt={post.data.heroImageAlt}
-        tags={post.data.tags}
-        href={withBase(`/blog/${post.id}/`)}
-        readingTime={showReadingTime ? readingTime(post.body) : undefined}
-        featured={post.data.featured}
-      />
-    ))
-  }
+<div class="posts-grid-shell">
+  <div class={`posts-grid posts-grid--${columns}`}>
+    {
+      posts.map((post) => (
+        <BlogCard
+          title={post.data.title}
+          description={post.data.description}
+          pubDate={post.data.pubDate}
+          heroImage={post.data.heroImage}
+          heroImageAlt={post.data.heroImageAlt}
+          tags={post.data.tags}
+          href={withBase(`/blog/${post.id}/`)}
+          readingTime={showReadingTime ? readingTime(post.body) : undefined}
+          featured={post.data.featured}
+        />
+      ))
+    }
+  </div>
 </div>
 
 <style>
+  /* The grid can't query itself, so the shell is the container and the grid
+     inside it reacts to how much room it was actually given. */
+  .posts-grid-shell {
+    container-type: inline-size;
+  }
+
   .posts-grid {
     display: grid;
     gap: var(--space-xl);
   }
 
+  /* min() keeps a track from demanding more than the container has, which is
+     what used to push the grid wider than its column on narrow screens. */
   .posts-grid--auto {
-    grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+    grid-template-columns: repeat(auto-fill, minmax(min(100%, 320px), 1fr));
   }
 
   .posts-grid--two {
-    grid-template-columns: repeat(auto-fit, minmax(350px, 1fr));
+    grid-template-columns: repeat(auto-fit, minmax(min(100%, 350px), 1fr));
   }
 
-  @media (max-width: 640px) {
+  /* Was a viewport query; the grid is just as narrow inside a 640px column on
+     a desktop, and now it collapses there too. */
+  @container (max-width: 640px) {
     .posts-grid {
       grid-template-columns: 1fr;
     }

--- a/src/components/common/Footer.astro
+++ b/src/components/common/Footer.astro
@@ -141,13 +141,25 @@ const footerLinks = siteConfig.footer.links.filter((link) => {
   .footer-container {
     max-width: var(--container-max);
     margin: 0 auto;
+    /* The grid inside queries this, not the viewport. */
+    container-type: inline-size;
   }
 
   .footer-grid {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+    /* min() stops a 250px track from outgrowing a narrower container. */
+    grid-template-columns: repeat(auto-fit, minmax(min(100%, 250px), 1fr));
     gap: var(--space-2xl);
     margin-bottom: var(--space-xl);
+  }
+
+  /* Was a viewport query: the footer columns depend on the footer's own width,
+     which is capped well below the window on a wide screen. */
+  @container (max-width: 768px) {
+    .footer-grid {
+      grid-template-columns: 1fr;
+      gap: var(--space-xl);
+    }
   }
 
   .footer-section {
@@ -270,11 +282,6 @@ const footerLinks = siteConfig.footer.links.filter((link) => {
 
   /* Mobile Styles */
   @media (max-width: 768px) {
-    .footer-grid {
-      grid-template-columns: 1fr;
-      gap: var(--space-xl);
-    }
-
     .footer-bottom {
       flex-direction: column;
       text-align: center;

--- a/src/components/common/GlassPanel.astro
+++ b/src/components/common/GlassPanel.astro
@@ -73,8 +73,8 @@ const radiusValue = radiusMap[radius];
   /* Minimal variant */
   .glass-panel--minimal {
     background: rgba(255, 255, 255, 0.02);
-    backdrop-filter: blur(4px);
-    -webkit-backdrop-filter: blur(4px);
+    backdrop-filter: blur(var(--glass-blur-xs));
+    -webkit-backdrop-filter: blur(var(--glass-blur-xs));
     border: 1px solid rgba(255, 255, 255, 0.05);
   }
 

--- a/src/components/common/Header.astro
+++ b/src/components/common/Header.astro
@@ -231,8 +231,9 @@ const navItems = getEnabledNavItems();
       left: 0;
       right: 0;
       background: var(--glass-bg-solid);
-      backdrop-filter: blur(20px) saturate(var(--glass-sat));
-      -webkit-backdrop-filter: blur(20px) saturate(var(--glass-sat));
+      backdrop-filter: blur(var(--glass-blur-lg)) saturate(var(--glass-sat));
+      -webkit-backdrop-filter: blur(var(--glass-blur-lg))
+        saturate(var(--glass-sat));
       border-bottom: 1px solid var(--glass-border);
       padding: var(--space-lg);
       transform: translateY(-100%);

--- a/src/components/common/SearchModal.astro
+++ b/src/components/common/SearchModal.astro
@@ -72,8 +72,9 @@
     padding: 0;
     color: var(--color-text);
     background: var(--glass-bg-solid);
-    backdrop-filter: blur(20px) saturate(var(--glass-sat));
-    -webkit-backdrop-filter: blur(20px) saturate(var(--glass-sat));
+    backdrop-filter: blur(var(--glass-blur-lg)) saturate(var(--glass-sat));
+    -webkit-backdrop-filter: blur(var(--glass-blur-lg))
+      saturate(var(--glass-sat));
     border: 1px solid var(--glass-border);
     border-radius: var(--radius-lg);
     box-shadow:

--- a/src/components/portfolio/WorkArchive.astro
+++ b/src/components/portfolio/WorkArchive.astro
@@ -111,33 +111,37 @@ const rangeEnd = indexOffset + projects.length;
     {
       projects.length > 0 ? (
         <>
-          <div class="project-grid">
-            {projects.map((project, index) => (
-              <div
-                class:list={[
-                  'project-shell',
-                  { 'project-shell--featured': project.data.featured },
-                ]}
-                data-technologies={
-                  showTechStack ? JSON.stringify(project.data.tech) : undefined
-                }
-              >
-                <ProjectCard
-                  title={project.data.title}
-                  summary={project.data.summary}
-                  cover={project.data.cover}
-                  coverAlt={project.data.coverAlt}
-                  tech={project.data.tech}
-                  role={project.data.role}
-                  year={project.data.year}
-                  href={withBase(`/work/${project.id}/`)}
-                  index={indexOffset + index + 1}
-                  featured={project.data.featured}
-                  showTechStack={showTechStack}
-                  showYear={showYear}
-                />
-              </div>
-            ))}
+          <div class="project-grid-shell">
+            <div class="project-grid">
+              {projects.map((project, index) => (
+                <div
+                  class:list={[
+                    'project-shell',
+                    { 'project-shell--featured': project.data.featured },
+                  ]}
+                  data-technologies={
+                    showTechStack
+                      ? JSON.stringify(project.data.tech)
+                      : undefined
+                  }
+                >
+                  <ProjectCard
+                    title={project.data.title}
+                    summary={project.data.summary}
+                    cover={project.data.cover}
+                    coverAlt={project.data.coverAlt}
+                    tech={project.data.tech}
+                    role={project.data.role}
+                    year={project.data.year}
+                    href={withBase(`/work/${project.id}/`)}
+                    index={indexOffset + index + 1}
+                    featured={project.data.featured}
+                    showTechStack={showTechStack}
+                    showYear={showYear}
+                  />
+                </div>
+              ))}
+            </div>
           </div>
           {showFilters && (
             <p class="filter-empty-state" hidden>
@@ -333,10 +337,27 @@ const rangeEnd = indexOffset + projects.length;
     outline-offset: 2px;
   }
 
+  /* The grid can't query its own width, so the shell is the container. */
+  .project-grid-shell {
+    container-type: inline-size;
+  }
+
   .project-grid {
     display: grid;
     grid-template-columns: repeat(2, minmax(0, 1fr));
     gap: var(--space-xl);
+  }
+
+  /* Was a viewport query: two project columns need room from the container,
+     not from the window. */
+  @container (max-width: 768px) {
+    .project-grid {
+      grid-template-columns: 1fr;
+    }
+
+    .project-shell--featured {
+      grid-column: auto;
+    }
   }
 
   .project-shell[hidden] {
@@ -384,14 +405,6 @@ const rangeEnd = indexOffset + projects.length;
     .filters {
       justify-content: flex-start;
       margin-top: var(--space-xl);
-    }
-
-    .project-grid {
-      grid-template-columns: 1fr;
-    }
-
-    .project-shell--featured {
-      grid-column: auto;
     }
   }
 

--- a/src/components/ui/Button.astro
+++ b/src/components/ui/Button.astro
@@ -122,8 +122,9 @@ const classes = [
   /* Glass variant */
   .btn--glass {
     background: var(--glass-bg);
-    backdrop-filter: blur(8px) saturate(var(--glass-sat));
-    -webkit-backdrop-filter: blur(8px) saturate(var(--glass-sat));
+    backdrop-filter: blur(var(--glass-blur-sm)) saturate(var(--glass-sat));
+    -webkit-backdrop-filter: blur(var(--glass-blur-sm))
+      saturate(var(--glass-sat));
     border-color: var(--glass-border);
     color: var(--color-text);
   }

--- a/src/styles/glass.css
+++ b/src/styles/glass.css
@@ -77,8 +77,8 @@
 /* Glass button */
 .glass-button {
   background: var(--glass-bg);
-  backdrop-filter: blur(8px) saturate(var(--glass-sat));
-  -webkit-backdrop-filter: blur(8px) saturate(var(--glass-sat));
+  backdrop-filter: blur(var(--glass-blur-sm)) saturate(var(--glass-sat));
+  -webkit-backdrop-filter: blur(var(--glass-blur-sm)) saturate(var(--glass-sat));
   border: 1px solid var(--glass-border);
   border-radius: var(--radius-md);
   padding: var(--space-sm) var(--space-lg);
@@ -128,8 +128,8 @@
 /* Glass navigation bar */
 .glass-nav {
   background: var(--glass-bg-solid);
-  backdrop-filter: blur(20px) saturate(var(--glass-sat));
-  -webkit-backdrop-filter: blur(20px) saturate(var(--glass-sat));
+  backdrop-filter: blur(var(--glass-blur-lg)) saturate(var(--glass-sat));
+  -webkit-backdrop-filter: blur(var(--glass-blur-lg)) saturate(var(--glass-sat));
   border-bottom: 1px solid var(--glass-border);
   box-shadow: 0 4px 30px rgba(0, 0, 0, 0.1);
   position: sticky;

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -104,8 +104,8 @@ pre {
   font-family: var(--font-mono);
   font-size: var(--text-sm);
   background: var(--glass-bg-solid);
-  backdrop-filter: blur(8px);
-  -webkit-backdrop-filter: blur(8px);
+  backdrop-filter: blur(var(--glass-blur-sm));
+  -webkit-backdrop-filter: blur(var(--glass-blur-sm));
   border: 1px solid var(--glass-border);
   border-radius: var(--radius-md);
   padding: var(--space-md);

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -12,7 +12,13 @@
   /* Glass effect */
   --glass-bg: rgba(255, 255, 255, 0.08);
   --glass-bg-solid: rgba(255, 255, 255, 0.7);
+  /* Blur steps. Only --glass-blur deepens in dark mode; the others describe a
+     surface's weight (a chip vs. the nav bar), which the theme doesn't change.
+     All of them drop to 0 under prefers-reduced-transparency below. */
+  --glass-blur-xs: 4px;
+  --glass-blur-sm: 8px;
   --glass-blur: 12px;
+  --glass-blur-lg: 20px;
   --glass-border: rgba(255, 255, 255, 0.18);
   --glass-shadow: 0 8px 32px 0 rgba(31, 38, 135, 0.15);
   --glass-sat: 180%;
@@ -131,14 +137,20 @@
   :root {
     --glass-bg: rgba(255, 255, 255, 0.95);
     --glass-bg-solid: rgba(255, 255, 255, 0.98);
+    --glass-blur-xs: 0px;
+    --glass-blur-sm: 0px;
     --glass-blur: 0px;
+    --glass-blur-lg: 0px;
     --glass-border: rgba(0, 0, 0, 0.1);
   }
 
   [data-theme='dark'] {
     --glass-bg: rgba(20, 20, 20, 0.95);
     --glass-bg-solid: rgba(10, 10, 10, 0.98);
+    --glass-blur-xs: 0px;
+    --glass-blur-sm: 0px;
     --glass-blur: 0px;
+    --glass-blur-lg: 0px;
     --glass-border: rgba(255, 255, 255, 0.1);
   }
 }

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -74,8 +74,11 @@
   --space-md: 1rem;
   --space-lg: 1.5rem;
   --space-xl: 2rem;
-  --space-2xl: 3rem;
-  --space-3xl: 4rem;
+  /* The two largest steps carry section rhythm, where a fixed 3/4rem is too
+     much air on a phone. They scale with the viewport and settle at the
+     previous values on a desktop-width screen. */
+  --space-2xl: clamp(2rem, 1.6rem + 2vw, 3rem);
+  --space-3xl: clamp(2.5rem, 2rem + 3vw, 4rem);
 
   /* Border radius */
   --radius-sm: 0.375rem;


### PR DESCRIPTION
Closes #47

## 概要

issue の 3 項目をそれぞれ独立したコミットにしています。

1. **blur トークン化** — ハードコードされた `blur(8px)` / `blur(20px)` / `blur(4px)` を `--glass-blur-xs/-sm/-lg` に集約
2. **fluid spacing** — `--space-2xl` / `--space-3xl` を `clamp()` 化
3. **Container Queries** — blog / project / footer の 3 グリッドをコンテナ幅基準に

## 1 は単なる整理ではなくバグ修正でした

`prefers-reduced-transparency: reduce` は `--glass-blur` を `0px` にしますが、**px 直書きの 6 面はそれを読んでいませんでした**。

| 面 | 旧 | 挙動 |
| --- | --- | --- |
| ナビバー / モバイルナビ / 検索モーダル | `blur(20px)` | 縮小指定を無視して 20px のまま |
| glass ボタン / `pre` ブロック | `blur(8px)` | 同上 |
| minimal glass パネル | `blur(4px)` | 同上 |

OS で透過を抑える設定をしている人に、**コンテンツの上に重なるヘッダーと検索オーバーレイ** — この設定が最も効くべき 2 面 — が 20px のぼかしを出し続けていました。トークン化に伴い media query 側で 0 にしています。

なお `--glass-blur` だけがダークモードで深くなり(12→16px)、新しい 3 段はテーマではなく「面の重さ」を表すので一定にしました。通常時の描画値は変わりません。

## 2 の効果

`--space-3xl` はセクションの上下パディング（`global.css` / `Section.astro`）に使われており、375px でも 1440px と同じ 4rem を消費していました。

- 390px 幅: **64px → 約 44px**
- 1100px 以上: 64px（従来どおり）

小さいステップはコンポーネント内部の間隔なので固定のままです。

## 3 の検証（ブラウザ実測）

グリッドは自分自身を query できないため、外側にシェル要素を置いて `container-type: inline-size` を付け、`@media` を `@container` に置き換えました。**ビューポートを 1411px に固定したまま、コンテナ幅だけを変えて計測**しています。

**blog グリッド**（`@container (max-width: 640px)`）

| コンテナ幅 | tracks | overflow |
| --- | --- | --- |
| 1104px / 800px | 2 トラック | なし |
| 700px / 640px / 500px | 1 トラック | なし |
| 320px / 280px / 240px / 200px | 1 トラック（コンテナ幅ぴったり） | **なし** |

最後の行が `minmax(min(100%, 320px), 1fr)` の効果です。従来の `minmax(320px, 1fr)` はコンテナが 320px を切ると溢れていました。

**project グリッド**（`@container (max-width: 768px)`）: 1104px → `536px 536px` / 900px → `434px 434px` / 768px 以下 → 1 トラック。overflow なし。

**footer グリッド**: 1104px → `320px 320px 320px` / 768px 以下 → 1 トラック。overflow なし。

ビューポートは全計測で 1411px のまま — **ウィンドウ幅ではなくコンテナ幅で切り替わっている**ことの証明です。

### 挙動が変わる点（意図的）

コンテナクエリは**コンテンツボックス**を測るため、フッターはウィンドウ幅ではなく「フッター自身の幅」が 768px を切った時点で 1 段になります。フッターは左右パディングの内側にあるので、**従来より少し広いウィンドウ幅で段組みが解除**されます。カラムが実際に入らない幅で解除されるので、こちらが正しい挙動と判断しました。

## 検証

- `npm run check` 0エラー / `npm run lint` 0 / `npm run format:check` OK / `npx astro build` 成功
- ブラウザ実測は上表のとおり。ページ描画は blog / work とも従来どおり（スクリーンショット確認）
- ⚠️ **main とのピクセル差分は取っていません。** 上記の計測とスクリーンショット目視での確認です

## 別件（このPRでは触っていません）

検証中に、**glassmorphism のぼかしが現行 Chrome で一切効いていない**ことが分かりました。

ビルド後の CSS には `-webkit-backdrop-filter` が 12 個ある一方、**標準の `backdrop-filter` が 0 個**です。Chrome 150 では全ての glass 面で `getComputedStyle(el).backdropFilter === 'none'` になります。ソース (`glass.css` 等) には両方書かれているので、`vite.build.cssMinify` の最小化で標準プロパティが落ちているようです。

`origin/main` をビルドしても **prefixed 20 / unprefixed 0** で同じなので、**このPRとは無関係な既存の問題**です。テーマの看板である視覚効果が出ていないので、別issueとして切る価値があります。
