### PR TITLE
fix(styles): put the standard backdrop-filter last so it survives the build

### DIFF
--- a/src/components/common/GlassPanel.astro
+++ b/src/components/common/GlassPanel.astro
@@ -53,8 +53,8 @@ const radiusValue = radiusMap[radius];
   /* Default variant */
   .glass-panel--default {
     background: var(--glass-bg);
-    backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-sat));
     -webkit-backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-sat));
+    backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-sat));
     border: 1px solid var(--glass-border);
     box-shadow:
       var(--glass-shadow),
@@ -64,8 +64,8 @@ const radiusValue = radiusMap[radius];
   /* Solid variant for better text readability */
   .glass-panel--solid {
     background: var(--glass-bg-solid);
-    backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-sat));
     -webkit-backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-sat));
+    backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-sat));
     border: 1px solid var(--glass-border);
     box-shadow: var(--glass-shadow);
   }
@@ -73,8 +73,8 @@ const radiusValue = radiusMap[radius];
   /* Minimal variant */
   .glass-panel--minimal {
     background: rgba(255, 255, 255, 0.02);
-    backdrop-filter: blur(var(--glass-blur-xs));
     -webkit-backdrop-filter: blur(var(--glass-blur-xs));
+    backdrop-filter: blur(var(--glass-blur-xs));
     border: 1px solid rgba(255, 255, 255, 0.05);
   }
 
@@ -123,8 +123,8 @@ const radiusValue = radiusMap[radius];
     .glass-panel--default,
     .glass-panel--solid {
       background: var(--color-surface);
-      backdrop-filter: none;
       -webkit-backdrop-filter: none;
+      backdrop-filter: none;
     }
 
     .glass-panel::before {

--- a/src/components/common/Header.astro
+++ b/src/components/common/Header.astro
@@ -231,9 +231,9 @@ const navItems = getEnabledNavItems();
       left: 0;
       right: 0;
       background: var(--glass-bg-solid);
-      backdrop-filter: blur(var(--glass-blur-lg)) saturate(var(--glass-sat));
       -webkit-backdrop-filter: blur(var(--glass-blur-lg))
         saturate(var(--glass-sat));
+      backdrop-filter: blur(var(--glass-blur-lg)) saturate(var(--glass-sat));
       border-bottom: 1px solid var(--glass-border);
       padding: var(--space-lg);
       transform: translateY(-100%);

--- a/src/components/common/SearchModal.astro
+++ b/src/components/common/SearchModal.astro
@@ -72,9 +72,9 @@
     padding: 0;
     color: var(--color-text);
     background: var(--glass-bg-solid);
-    backdrop-filter: blur(var(--glass-blur-lg)) saturate(var(--glass-sat));
     -webkit-backdrop-filter: blur(var(--glass-blur-lg))
       saturate(var(--glass-sat));
+    backdrop-filter: blur(var(--glass-blur-lg)) saturate(var(--glass-sat));
     border: 1px solid var(--glass-border);
     border-radius: var(--radius-lg);
     box-shadow:

--- a/src/components/ui/Button.astro
+++ b/src/components/ui/Button.astro
@@ -122,9 +122,9 @@ const classes = [
   /* Glass variant */
   .btn--glass {
     background: var(--glass-bg);
-    backdrop-filter: blur(var(--glass-blur-sm)) saturate(var(--glass-sat));
     -webkit-backdrop-filter: blur(var(--glass-blur-sm))
       saturate(var(--glass-sat));
+    backdrop-filter: blur(var(--glass-blur-sm)) saturate(var(--glass-sat));
     border-color: var(--glass-border);
     color: var(--color-text);
   }

--- a/src/styles/glass.css
+++ b/src/styles/glass.css
@@ -1,10 +1,18 @@
 /* Glass Morphism Effects - Core System */
 
+/* Declaration order matters here, and not for the usual cascade reason: the CSS
+   pipeline collapses `backdrop-filter` and `-webkit-backdrop-filter` into one
+   declaration and keeps whichever was written last. Only one of the two ever
+   reaches the browser, so the standard property goes second — the prefixed one
+   alone leaves current Chrome with no blur at all. Safari below 18 then has no
+   backdrop-filter to match and picks up the `@supports not` fallback at the
+   bottom of this file. */
+
 /* Base glass mixin */
 .glass {
   background: var(--glass-bg);
-  backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-sat));
   -webkit-backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-sat));
+  backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-sat));
   border: 1px solid var(--glass-border);
   box-shadow: var(--glass-shadow);
   transition:
@@ -17,8 +25,8 @@
 /* Glass panel component */
 .glass-panel {
   background: var(--glass-bg);
-  backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-sat));
   -webkit-backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-sat));
+  backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-sat));
   border: 1px solid var(--glass-border);
   border-radius: var(--radius-lg);
   box-shadow:
@@ -50,8 +58,8 @@
 /* Interactive glass card */
 .glass-card {
   background: var(--glass-bg);
-  backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-sat));
   -webkit-backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-sat));
+  backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-sat));
   border: 1px solid var(--glass-border);
   border-radius: var(--radius-lg);
   box-shadow: var(--glass-shadow);
@@ -77,8 +85,8 @@
 /* Glass button */
 .glass-button {
   background: var(--glass-bg);
-  backdrop-filter: blur(var(--glass-blur-sm)) saturate(var(--glass-sat));
   -webkit-backdrop-filter: blur(var(--glass-blur-sm)) saturate(var(--glass-sat));
+  backdrop-filter: blur(var(--glass-blur-sm)) saturate(var(--glass-sat));
   border: 1px solid var(--glass-border);
   border-radius: var(--radius-md);
   padding: var(--space-sm) var(--space-lg);
@@ -128,8 +136,8 @@
 /* Glass navigation bar */
 .glass-nav {
   background: var(--glass-bg-solid);
-  backdrop-filter: blur(var(--glass-blur-lg)) saturate(var(--glass-sat));
   -webkit-backdrop-filter: blur(var(--glass-blur-lg)) saturate(var(--glass-sat));
+  backdrop-filter: blur(var(--glass-blur-lg)) saturate(var(--glass-sat));
   border-bottom: 1px solid var(--glass-border);
   box-shadow: 0 4px 30px rgba(0, 0, 0, 0.1);
   position: sticky;

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -104,8 +104,8 @@ pre {
   font-family: var(--font-mono);
   font-size: var(--text-sm);
   background: var(--glass-bg-solid);
-  backdrop-filter: blur(var(--glass-blur-sm));
   -webkit-backdrop-filter: blur(var(--glass-blur-sm));
+  backdrop-filter: blur(var(--glass-blur-sm));
   border: 1px solid var(--glass-border);
   border-radius: var(--radius-md);
   padding: var(--space-md);


### PR DESCRIPTION
Closes #75

## 訂正: issue に書いた原因は間違いでした

issue #75 では「`cssMinify` の最小化が標準プロパティを落としている」と書きましたが、**違いました**。切り分けの記録:

| 試したこと | prefixed | unprefixed |
| --- | --- | --- |
| ベースライン（`cssMinify: true`） | 20 | 0 |
| `cssMinify: false` | 20 | **0**（変わらず） |
| `css.lightningcss.targets` に safari 15 を明示 | 20 | **0**（変わらず） |
| **宣言の順序を入れ替え** | 0 | **20** ✅ |

## 本当の原因

CSS パイプラインは `backdrop-filter` と `-webkit-backdrop-filter` を**同一プロパティとして畳み込み、後に書いた方だけを残します**。出力側でこの2つが同居している規則は 1 つもありませんでした（実測）。

このリポジトリは全ての規則で**標準を先、`-webkit-` を後**に書いていたため、ビルド成果物には `-webkit-backdrop-filter` が 20 個・標準が 0 個。そして現行 Chrome はこのプレフィックス版を尊重しません。

結果、**テーマの名前の由来である glassmorphism のぼかしが Chrome で完全に無効**でした（半透明背景だけが出ていたので、それらしくは見えていた）。

## 修正

10 組すべての順序を入れ替えただけです。CSS の慣習どおり「プレフィックス版を先、標準を後」になります。

```diff
-  backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-sat));
   -webkit-backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-sat));
+  backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-sat));
```

順序が意味を持つ理由は一見して分からず「直したくなる」ので、`glass.css` の先頭にコメントを残しました。

## 検証（Chrome 150 実測）

| セレクタ | 修正前 | 修正後 |
| --- | --- | --- |
| `.glass-nav` | `none` | `blur(20px) saturate(1.8)` |
| `.glass-card` | `none` | `blur(12px) saturate(1.8)` |
| `.glass-panel` | `none` | `blur(12px) saturate(1.8)` |

ビルド成果物: prefixed **20 → 0** / unprefixed **0 → 20**。

スクロールしてスティッキーヘッダーの背後にコンテンツを置いた状態のスクリーンショットで、フィルタチップがヘッダー越しにぼけていることを目視確認しました。

- `npm run check` 0エラー / `npm run lint` 0 / `npm run format:check` OK / `npx astro build` 成功

## Safari について

Safari 18 未満は標準プロパティを解釈できないため、ぼかしが出なくなります。ただし `glass.css` 末尾の

```css
@supports not (backdrop-filter: blur(1px)) { … background: var(--color-surface); opacity: .95 }
```

が拾うので、**不透明な背景に degrade**します（読めなくなることはありません）。

両方を出力させる方法は上表のとおり見つかりませんでした（畳み込みは最小化を切っても targets を明示しても起きる）。どちらか一方しか選べない以上、**Chrome / Firefox / Edge / Safari 18+ を取る**判断です。