### PR TITLE
feat(styles): scroll-driven reveal for sections and cards

### DIFF
--- a/src/components/blog/BlogCard.astro
+++ b/src/components/blog/BlogCard.astro
@@ -15,6 +15,7 @@ export interface Props {
   href: string;
   readingTime?: number;
   featured?: boolean;
+  class?: string;
 }
 
 const {
@@ -27,12 +28,13 @@ const {
   href,
   readingTime,
   featured = false,
+  class: className = '',
 } = Astro.props;
 
 const formattedDate = formatDate(pubDate);
 ---
 
-<article class="blog-card glass-card">
+<article class:list={['blog-card', 'glass-card', className]}>
   {
     heroImage && (
       <a

--- a/src/components/blog/PostGrid.astro
+++ b/src/components/blog/PostGrid.astro
@@ -21,6 +21,7 @@ const showReadingTime = siteConfig.blog.showReadingTime;
     {
       posts.map((post) => (
         <BlogCard
+          class="reveal"
           title={post.data.title}
           description={post.data.description}
           pubDate={post.data.pubDate}

--- a/src/components/landing/Benefits.astro
+++ b/src/components/landing/Benefits.astro
@@ -8,7 +8,7 @@ export interface Props {
 const { benefits } = Astro.props;
 ---
 
-<section class="benefits" aria-labelledby="benefits-title">
+<section class="benefits reveal" aria-labelledby="benefits-title">
   <Container size="xl">
     <div class="benefits__intro">
       <p>Why it matters</p>

--- a/src/components/landing/Faq.astro
+++ b/src/components/landing/Faq.astro
@@ -8,7 +8,7 @@ export interface Props {
 const { items } = Astro.props;
 ---
 
-<section class="faq" id="faq" aria-labelledby="faq-title">
+<section class="faq reveal" id="faq" aria-labelledby="faq-title">
   <Container size="md">
     <p class="faq__eyebrow">Questions, answered</p>
     <h2 id="faq-title">Before you begin.</h2>

--- a/src/components/landing/Features.astro
+++ b/src/components/landing/Features.astro
@@ -14,6 +14,7 @@ const { features } = Astro.props;
 ---
 
 <Section
+  class="reveal"
   id="features"
   eyebrow="The collection"
   title="Useful by design."

--- a/src/components/landing/FinalCta.astro
+++ b/src/components/landing/FinalCta.astro
@@ -13,7 +13,7 @@ export interface Props {
 const { cta } = Astro.props;
 ---
 
-<section class="final-cta">
+<section class="final-cta reveal">
   <Container size="xl">
     <div class="final-cta__panel">
       <span class="final-cta__mark" aria-hidden="true">✦</span>

--- a/src/components/landing/Gallery.astro
+++ b/src/components/landing/Gallery.astro
@@ -10,6 +10,7 @@ const { images } = Astro.props;
 ---
 
 <Section
+  class="reveal"
   id="gallery"
   eyebrow="In context"
   title="Objects with room to breathe."

--- a/src/components/landing/Pricing.astro
+++ b/src/components/landing/Pricing.astro
@@ -19,6 +19,7 @@ const { plans } = Astro.props;
 ---
 
 <Section
+  class="reveal"
   id="pricing"
   eyebrow="Editions"
   title="Choose your starting point."

--- a/src/components/landing/Testimonials.astro
+++ b/src/components/landing/Testimonials.astro
@@ -15,6 +15,7 @@ const { testimonials } = Astro.props;
 ---
 
 <Section
+  class="reveal"
   id="stories"
   eyebrow="Field reports"
   title="Kept, used, recommended."

--- a/src/components/portfolio/WorkArchive.astro
+++ b/src/components/portfolio/WorkArchive.astro
@@ -117,6 +117,7 @@ const rangeEnd = indexOffset + projects.length;
                 <div
                   class:list={[
                     'project-shell',
+                    'reveal',
                     { 'project-shell--featured': project.data.featured },
                   ]}
                   data-technologies={
@@ -405,31 +406,6 @@ const rangeEnd = indexOffset + projects.length;
     .filters {
       justify-content: flex-start;
       margin-top: var(--space-xl);
-    }
-  }
-
-  @media (prefers-reduced-motion: no-preference) {
-    .project-shell {
-      animation: project-enter 500ms both;
-    }
-
-    .project-shell:nth-child(2) {
-      animation-delay: 80ms;
-    }
-
-    .project-shell:nth-child(3) {
-      animation-delay: 160ms;
-    }
-
-    .project-shell:nth-child(4) {
-      animation-delay: 240ms;
-    }
-  }
-
-  @keyframes project-enter {
-    from {
-      opacity: 0;
-      transform: translateY(1rem);
     }
   }
 </style>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -92,6 +92,7 @@ const showcases = [
     </section>
 
     <Section
+      class="reveal"
       id="showcase"
       eyebrow="Choose your canvas"
       title="Three complete starting points."
@@ -176,7 +177,7 @@ const showcases = [
       </div>
     </Section>
 
-    <section class="system-note">
+    <section class="system-note reveal">
       <Container size="xl">
         <div>
           <span class="system-note__index">04 / FOUNDATION</span>
@@ -207,7 +208,7 @@ const showcases = [
       </Container>
     </section>
 
-    <section class="home-cta">
+    <section class="home-cta reveal">
       <Container size="xl">
         <p>Start with a structure. Make the atmosphere yours.</p>
         <h2>Pick a page and begin.</h2>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -351,3 +351,41 @@ button {
     display: flex;
   }
 }
+
+/* Scroll-driven entrance
+ *
+ * `.reveal` fades and lifts an element as it scrolls into view. The whole thing
+ * — animation, keyframes, the opacity: 0 start — lives inside the @supports
+ * block, so a browser without view() timelines never applies a starting state
+ * it has no way to animate away from: the content is simply there, at full
+ * opacity, from the first paint. That's the failure mode to design for; a
+ * JS-free reveal that hides content on unsupported browsers is worse than no
+ * reveal at all.
+ *
+ * Only opacity and transform animate, so nothing here can shift layout.
+ */
+@media (prefers-reduced-motion: no-preference) {
+  @supports (animation-timeline: view()) {
+    .reveal {
+      animation-name: reveal-in;
+      /* Required, and not the default: a progress-based timeline needs
+         `auto` to map the range onto the animation. Left unset it resolves to
+         a 0% duration, the animation never becomes active, and the element
+         just sits at its base style. */
+      animation-duration: auto;
+      animation-timing-function: linear;
+      animation-fill-mode: both;
+      animation-timeline: view();
+      /* Finish well before the element reaches the middle of the screen —
+         a reveal still running when you're reading it is a distraction. */
+      animation-range: entry 0% entry 40%;
+    }
+
+    @keyframes reveal-in {
+      from {
+        opacity: 0;
+        transform: translateY(1.5rem);
+      }
+    }
+  }
+}


### PR DESCRIPTION
Closes #44

## 概要

`.reveal` ユーティリティを `global.css` に追加し、スクロールに応じた入場演出を JS なしで実装しました。

```css
@media (prefers-reduced-motion: no-preference) {
  @supports (animation-timeline: view()) {
    .reveal {
      animation-name: reveal-in;
      animation-duration: auto;
      animation-timing-function: linear;
      animation-fill-mode: both;
      animation-timeline: view();
      animation-range: entry 0% entry 40%;
    }
    @keyframes reveal-in {
      from { opacity: 0; transform: translateY(1.5rem); }
    }
  }
}
```

適用先: ホームのセクション（ヒーロー以外）/ landing の全セクション / blog カード / project カード。

## 実装中に踏んだ罠 2 つ

どちらも「書いたのに何も起きない」形で出るので記録します。

### 1. ミニファイアが `animation-timeline` をショートハンドに畳み込む

最初は issue の例どおり `animation: reveal-in linear both;` + `animation-timeline: view();` と書きました。ビルド後:

```css
.reveal{animation:linear both reveal-in view();animation-range:entry entry 40%}
```

`animation-timeline` は**仕様上ショートハンドに含められないプロパティ**（ショートハンドはこれを `auto` にリセットするだけ）なので、`view()` が混入した宣言はブラウザに丸ごと捨てられます。実測でも `animationName: "none"` / `animationTimeline: "auto"` でした。

longhand で書くと畳み込まれず、そのまま出力されます。

### 2. `animation-duration: auto` は省略できない

longhand にしてもまだ動かず、調べると:

```
getComputedTiming() → { duration: "0%", activeDuration: "0%", progress: null }
```

progress ベースのタイムラインでは `animation-duration: auto` が必要で、未指定だと `0s` → `0%` に解決され、アニメーションが有効化されません。既定値に見えるので**明示的に書いて、理由をコメントに残しました**。

## 安全性（最重要）

受け入れ条件の「非対応ブラウザ・reduced-motion で内容が欠けずに即時表示される」を静的に検証しました。ビルド成果物に対して `.reveal` 規則の囲みを解析:

```
guarded .reveal rules  : 1
UNGUARDED .reveal rules: 0   ← 0 であること
```

`opacity: 0` の開始状態を含む一切が `@supports` + `prefers-reduced-motion` の内側にあるため、**view() タイムラインを持たないブラウザにはルート自体が届かず、初回ペイントから不透明で表示**されます。「JS なしの reveal が非対応ブラウザでコンテンツを隠す」という最悪の失敗はしません。

CLS も起きません（opacity と transform のみ）。

## WorkArchive の一斉発火を置き換え

`project-enter` は**ページロード時に全カードが同時発火**していたため、ファーストビュー外のカードは到達時にはアニメーションが終わっており、読者には静止したカードしか見えていませんでした。nth-child で手書きしていた stagger も、カードの位置から自然に出るようになります。

BlogCard には `class` prop を追加しました（GlassCard / Section と同じ流儀）。

## ⚠️ 未確認事項

**アニメーションが実際に再生される様子は確認できていません。**

自動操作しているタブが `document.visibilityState === "hidden"` のままで、Chrome はこの状態だと CSS スクロール駆動アニメーションを進行させません（`timeline.currentTime` が常に `null`）。同じ要素に対して **JS で `new ViewTimeline({subject})` を作ると `currentTime: 29.7%` を返す**ので、要素・スクロール幾何・レンジの側は正しく、CSS の配線も出力を見る限り正しい、というところまでは確認できています。

手元のブラウザで実際にスクロールしての目視確認をお願いします。確認ポイント:

- ホーム / landing のセクションが下からふわっと入ってくる
- blog / work のカードが画面に入ったタイミングで個別に入場する
- 一番下までスクロールして**消えたまま残る要素がない**
- OS で「視差効果を減らす」を有効にすると演出が止まり、内容は即表示される

## 検証済み

- `npm run check` 0エラー / `npm run lint` 0 / `npm run format:check` OK / `npx astro build` 成功
- 出力 CSS に longhand 6 プロパティがそのまま含まれること
- `.reveal` 要素数: home 3 / blog 2 / work 4 / landing 7
- ビルド成果物での囲み検証（上記）
