### PR TITLE
feat(nav): navigate client-side with ClientRouter

### DIFF
--- a/src/components/blog/Toc.astro
+++ b/src/components/blog/Toc.astro
@@ -31,13 +31,24 @@ const items = headings.filter(
 }
 
 <script>
+  import { onPage } from '@/lib/lifecycle';
+
   // Scrollspy: highlight the TOC entry for the heading currently in view.
-  const links = Array.from(
-    document.querySelectorAll<HTMLAnchorElement>('[data-toc-link]'),
-  );
-  if (links.length > 0 && 'IntersectionObserver' in window) {
+  // The observer is torn down and rebuilt per page — left alone it would keep
+  // watching headings that the navigation detached.
+  let observer: IntersectionObserver | null = null;
+
+  onPage(() => {
+    observer?.disconnect();
+    observer = null;
+
+    const links = Array.from(
+      document.querySelectorAll<HTMLAnchorElement>('[data-toc-link]'),
+    );
+    if (links.length === 0 || !('IntersectionObserver' in window)) return;
+
     const bySlug = new Map(links.map((l) => [l.dataset.tocLink, l]));
-    const observer = new IntersectionObserver(
+    observer = new IntersectionObserver(
       (entries) => {
         for (const entry of entries) {
           if (entry.isIntersecting) {
@@ -53,7 +64,7 @@ const items = headings.filter(
       const heading = id ? document.getElementById(id) : null;
       if (heading) observer.observe(heading);
     }
-  }
+  });
 </script>
 
 <style>

--- a/src/components/common/AuroraBackground.astro
+++ b/src/components/common/AuroraBackground.astro
@@ -168,11 +168,17 @@ const opacity = opacityMap[intensity];
 </style>
 
 <script>
-  // Pause aurora animation when the tab is backgrounded.
-  const aurora = document.querySelector('.aurora-background');
-  if (aurora) {
-    const sync = () => aurora.classList.toggle('is-paused', document.hidden);
-    document.addEventListener('visibilitychange', sync);
-    sync();
+  import { onPage } from '@/lib/lifecycle';
+
+  // Pause aurora animation when the tab is backgrounded. The element is
+  // replaced on navigation, so it is looked up when the state is applied
+  // rather than captured once.
+  function sync() {
+    document
+      .querySelector('.aurora-background')
+      ?.classList.toggle('is-paused', document.hidden);
   }
+
+  document.addEventListener('visibilitychange', sync);
+  onPage(sync);
 </script>

--- a/src/components/common/Header.astro
+++ b/src/components/common/Header.astro
@@ -305,10 +305,11 @@ const navItems = getEnabledNavItems();
 
 <script>
   import { lockScroll, unlockScroll } from '@/lib/scrollLock';
+  import { onPage, onLeave } from '@/lib/lifecycle';
 
-  // Mobile menu toggle
-  const toggle = document.getElementById('menu-toggle');
-  const nav = document.getElementById('navigation');
+  // Re-queried on every navigation; the old elements go away with the swap.
+  let toggle: HTMLElement | null = null;
+  let nav: HTMLElement | null = null;
   const mobile = window.matchMedia('(max-width: 768px)');
 
   // The menu collapses behind a hamburger only at ≤768px. When it's collapsed
@@ -340,13 +341,27 @@ const navItems = getEnabledNavItems();
     syncNavState();
   }
 
-  toggle?.addEventListener('click', () => {
-    if (nav?.classList.contains('active')) {
-      closeMenu();
-    } else {
-      openMenu();
-    }
+  onPage(() => {
+    toggle = document.getElementById('menu-toggle');
+    nav = document.getElementById('navigation');
+
+    toggle?.addEventListener('click', () => {
+      if (nav?.classList.contains('active')) {
+        closeMenu();
+      } else {
+        openMenu();
+      }
+    });
+
+    syncNavState();
   });
+
+  // The scroll lock lives on <html>, which survives the swap: leaving the menu
+  // open through a navigation would lock scrolling on the page you land on.
+  onLeave(closeMenu);
+
+  // Listeners below are on objects that outlive the swap, so they are
+  // registered once and read whichever elements are current.
 
   // Close menu when clicking outside
   document.addEventListener('click', (e) => {
@@ -364,9 +379,9 @@ const navItems = getEnabledNavItems();
     }
   });
 
-  // Keep inert/aria-hidden correct across viewport changes (and on load).
+  // Keep inert/aria-hidden correct across viewport changes.
   mobile.addEventListener('change', () => {
     closeMenu();
+    syncNavState();
   });
-  syncNavState();
 </script>

--- a/src/components/common/SearchModal.astro
+++ b/src/components/common/SearchModal.astro
@@ -264,15 +264,15 @@
 
 <script>
   import { lockScroll, unlockScroll } from '@/lib/scrollLock';
+  import { onPage, onLeave } from '@/lib/lifecycle';
 
-  const dialog = document.getElementById(
-    'search-modal',
-  ) as HTMLDialogElement | null;
-  const input = document.getElementById(
-    'search-input',
-  ) as HTMLInputElement | null;
-  const status = document.getElementById('search-status');
-  const resultsList = document.getElementById('search-results');
+  // The modal is part of the swapped body, so these are re-queried per page.
+  // `pagefind` below deliberately is not: the index is expensive to load and
+  // stays valid for the whole session.
+  let dialog: HTMLDialogElement | null = null;
+  let input: HTMLInputElement | null = null;
+  let status: HTMLElement | null = null;
+  let resultsList: HTMLElement | null = null;
 
   // BASE_URL may or may not carry a trailing slash depending on config;
   // normalize so concatenation below is predictable (same as lib/url.ts).
@@ -399,25 +399,46 @@
     loadPagefind();
   }
 
-  input?.addEventListener('input', (e) =>
-    runSearch((e.target as HTMLInputElement).value),
-  );
+  onPage(() => {
+    dialog = document.getElementById(
+      'search-modal',
+    ) as HTMLDialogElement | null;
+    input = document.getElementById('search-input') as HTMLInputElement | null;
+    status = document.getElementById('search-status');
+    resultsList = document.getElementById('search-results');
 
-  dialog?.addEventListener('close', () => {
-    unlockScroll();
+    input?.addEventListener('input', (e) =>
+      runSearch((e.target as HTMLInputElement).value),
+    );
+
+    dialog?.addEventListener('close', () => {
+      unlockScroll();
+    });
+
+    // Close when the backdrop (the dialog element itself) is clicked.
+    dialog?.addEventListener('click', (e) => {
+      if (e.target === dialog) dialog?.close();
+    });
+
+    dialog
+      ?.querySelector('[data-search-close]')
+      ?.addEventListener('click', () => dialog?.close());
+
+    // Any trigger on the page opens the modal.
+    document.querySelectorAll('[data-search-open]').forEach((el) => {
+      el.addEventListener('click', openModal);
+    });
   });
 
-  // Close when the backdrop (the dialog element itself) is clicked.
-  dialog?.addEventListener('click', (e) => {
-    if (e.target === dialog) dialog.close();
-  });
+  // A dialog left open through a navigation takes its scroll lock — which
+  // lives on <html> — with it to the next page.
+  onLeave(() => dialog?.close());
 
-  dialog
-    ?.querySelector('[data-search-close]')
-    ?.addEventListener('click', () => dialog.close());
-
-  // Roving focus between the input and result links with ↑/↓.
-  dialog?.addEventListener('keydown', (e) => {
+  // Roving focus between the input and result links with ↑/↓. Bound on
+  // `document` so it survives the swap; it does nothing unless the modal is
+  // open, which is the only time the dialog holds focus.
+  document.addEventListener('keydown', (e) => {
+    if (!dialog?.open) return;
     if (e.key !== 'ArrowDown' && e.key !== 'ArrowUp') return;
     e.preventDefault();
     const links = Array.from(
@@ -431,11 +452,7 @@
     stops[next]?.focus();
   });
 
-  // Any trigger on the page opens the modal; ⌘K / Ctrl+K toggles it.
-  document.querySelectorAll('[data-search-open]').forEach((el) => {
-    el.addEventListener('click', openModal);
-  });
-
+  // ⌘K / Ctrl+K toggles the modal from anywhere.
   window.addEventListener('keydown', (e) => {
     if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 'k') {
       e.preventDefault();

--- a/src/components/common/ThemeToggle.astro
+++ b/src/components/common/ThemeToggle.astro
@@ -156,12 +156,12 @@ const defaultMode = siteConfig.theme.defaultColorMode;
 </style>
 
 <script>
-  // Theme toggle functionality
-  const toggle = document.getElementById('theme-toggle');
-  const themes = ['system', 'light', 'dark'];
+  import { onPage } from '@/lib/lifecycle';
 
-  // Fallback when the visitor has no saved preference, from site.config.
-  const defaultMode = toggle?.dataset.defaultMode ?? 'system';
+  // Theme toggle functionality. The button is re-queried on every navigation.
+  let toggle: HTMLElement | null = null;
+  let defaultMode = 'system';
+  const themes = ['system', 'light', 'dark'];
 
   // localStorage can throw (Safari "block all cookies", private mode, sandboxed
   // iframes). Wrap every access so a failure degrades gracefully instead of
@@ -258,13 +258,25 @@ const defaultMode = siteConfig.theme.defaultColorMode;
     }, 1000);
   }
 
-  // Reflect the current mode in aria-label on load. BaseLayout's inline
-  // FOUC-prevention script already set data-theme/-theme-mode on <html>
-  // before this runs, but not the button's label.
-  updateAriaLabel(getThemePreference());
+  onPage(() => {
+    toggle = document.getElementById('theme-toggle');
+    // Fallback when the visitor has no saved preference, from site.config.
+    defaultMode = toggle?.dataset.defaultMode ?? 'system';
 
-  // Set up event listener
-  toggle?.addEventListener('click', cycleTheme);
+    // Reflect the current mode in aria-label. BaseLayout's inline
+    // FOUC-prevention script already set data-theme/-theme-mode on <html>
+    // before this runs, but not the button's label.
+    updateAriaLabel(getThemePreference());
+    toggle?.addEventListener('click', cycleTheme);
+  });
+
+  // A client-side navigation copies the incoming document's <html> attributes
+  // over the live ones, and the static HTML carries no data-theme — only the
+  // inline script sets it, and that script does not run again. Without this the
+  // page would flash back to the default appearance on every navigation.
+  document.addEventListener('astro:after-swap', () => {
+    applyTheme(getThemePreference());
+  });
 
   // Re-resolve when the OS preference changes while in "system" mode.
   try {

--- a/src/components/portfolio/WorkArchive.astro
+++ b/src/components/portfolio/WorkArchive.astro
@@ -165,59 +165,71 @@ const rangeEnd = indexOffset + projects.length;
 </section>
 
 <script>
-  const buttons = Array.from(
-    document.querySelectorAll<HTMLButtonElement>('[data-filter]'),
-  );
-  const projects = Array.from(
-    document.querySelectorAll<HTMLElement>('[data-technologies]'),
-  );
-  const status = document.querySelector<HTMLElement>('.filter-status');
-  const emptyState = document.querySelector<HTMLElement>('.filter-empty-state');
-  const prefersReducedMotion = window.matchMedia(
-    '(prefers-reduced-motion: reduce)',
-  ).matches;
+  import { onPage } from '@/lib/lifecycle';
 
-  buttons.forEach((button) => {
-    button.addEventListener('click', () => {
-      const selected = button.dataset.filter ?? 'all';
-      let visibleCount = 0;
+  // The filter runs over the cards on the current page, so every element here
+  // is looked up again after a navigation — leaving /work/ and coming back
+  // would otherwise land on a page whose filter buttons do nothing.
+  onPage(() => {
+    const buttons = Array.from(
+      document.querySelectorAll<HTMLButtonElement>('[data-filter]'),
+    );
+    if (buttons.length === 0) return;
 
-      buttons.forEach((item) => {
-        const isSelected = item === button;
-        item.classList.toggle('is-active', isSelected);
-        item.setAttribute('aria-pressed', String(isSelected));
-      });
+    const projects = Array.from(
+      document.querySelectorAll<HTMLElement>('[data-technologies]'),
+    );
+    const status = document.querySelector<HTMLElement>('.filter-status');
+    const emptyState = document.querySelector<HTMLElement>(
+      '.filter-empty-state',
+    );
+    const prefersReducedMotion = window.matchMedia(
+      '(prefers-reduced-motion: reduce)',
+    ).matches;
 
-      projects.forEach((project) => {
-        let technologies: string[] = [];
-        try {
-          technologies = JSON.parse(
-            project.dataset.technologies ?? '[]',
-          ) as string[];
-        } catch {
-          technologies = [];
-        }
-        const isVisible = selected === 'all' || technologies.includes(selected);
-        project.hidden = !isVisible;
-        if (isVisible) {
-          visibleCount += 1;
-          if (!prefersReducedMotion) {
-            project.animate(
-              [
-                { opacity: 0, transform: 'translateY(1rem)' },
-                { opacity: 1, transform: 'translateY(0)' },
-              ],
-              { duration: 300, easing: 'ease-out' },
-            );
+    buttons.forEach((button) => {
+      button.addEventListener('click', () => {
+        const selected = button.dataset.filter ?? 'all';
+        let visibleCount = 0;
+
+        buttons.forEach((item) => {
+          const isSelected = item === button;
+          item.classList.toggle('is-active', isSelected);
+          item.setAttribute('aria-pressed', String(isSelected));
+        });
+
+        projects.forEach((project) => {
+          let technologies: string[] = [];
+          try {
+            technologies = JSON.parse(
+              project.dataset.technologies ?? '[]',
+            ) as string[];
+          } catch {
+            technologies = [];
           }
+          const isVisible =
+            selected === 'all' || technologies.includes(selected);
+          project.hidden = !isVisible;
+          if (isVisible) {
+            visibleCount += 1;
+            if (!prefersReducedMotion) {
+              project.animate(
+                [
+                  { opacity: 0, transform: 'translateY(1rem)' },
+                  { opacity: 1, transform: 'translateY(0)' },
+                ],
+                { duration: 300, easing: 'ease-out' },
+              );
+            }
+          }
+        });
+
+        if (emptyState) emptyState.hidden = visibleCount > 0;
+
+        if (status) {
+          status.textContent = `${visibleCount} project${visibleCount === 1 ? '' : 's'} shown`;
         }
       });
-
-      if (emptyState) emptyState.hidden = visibleCount > 0;
-
-      if (status) {
-        status.textContent = `${visibleCount} project${visibleCount === 1 ? '' : 's'} shown`;
-      }
     });
   });
 </script>

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -2,6 +2,7 @@
 import '@/styles/global.css';
 import siteConfig from '@/site.config';
 import { withBase } from '@/lib/url';
+import { ClientRouter } from 'astro:transitions';
 import Seo from '@/components/common/Seo.astro';
 import AuroraBackground from '@/components/common/AuroraBackground.astro';
 import ThemeToggle from '@/components/common/ThemeToggle.astro';
@@ -31,6 +32,13 @@ const props = Astro.props;
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="generator" content={Astro.generator} />
+
+    <!-- Client-side routing. Astro falls back to a normal navigation where the
+         View Transitions API is missing, and skips the animation entirely under
+         prefers-reduced-motion, so this costs nothing where it isn't wanted.
+         Component scripts re-initialise on `astro:page-load`; see the note in
+         src/lib/lifecycle.ts. -->
+    <ClientRouter />
 
     <!-- Favicon & app icons -->
     <link rel="icon" type="image/svg+xml" href={withBase('/favicon.svg')} />

--- a/src/lib/lifecycle.ts
+++ b/src/lib/lifecycle.ts
@@ -1,0 +1,40 @@
+// Component scripts and client-side routing
+//
+// With `<ClientRouter />` in BaseLayout, a navigation swaps the document body
+// but does *not* re-evaluate a module script that already ran. That splits any
+// component script into two kinds of work:
+//
+//   - Wiring to elements inside the swapped body — listeners on a button, a
+//     dialog, an observer over headings. Those elements are replaced on every
+//     navigation, so this must run again each time. Pass it to `onPage()`.
+//
+//   - Wiring to things that outlive the swap — `document`, `window`, a
+//     `matchMedia` query. Those listeners survive, so registering them again
+//     would fire the handler twice per event. Leave that at the top level of
+//     the script, where it runs once per full page load.
+//
+// Because the elements are new each time, re-adding element listeners in
+// `onPage()` cannot double-register: the old element (and its listeners) is
+// already gone.
+
+/**
+ * Run `setup` on the first page load and after every client-side navigation.
+ *
+ * `astro:page-load` fires in both cases — including for a script that was
+ * pulled in by the navigation itself — so `setup` must not also be called
+ * directly, or it runs twice on the initial load.
+ */
+export function onPage(setup: () => void): void {
+  document.addEventListener('astro:page-load', setup);
+}
+
+/**
+ * Run `teardown` just before the body is swapped out.
+ *
+ * Anything that reaches outside the swapped subtree has to be undone here:
+ * a scroll lock lives on `<html>`, which survives the swap, so a menu left
+ * open during a navigation would freeze scrolling on the next page.
+ */
+export function onLeave(teardown: () => void): void {
+  document.addEventListener('astro:before-swap', teardown);
+}


### PR DESCRIPTION
Refs #43（issue の備考どおり 2 PR に分割。これは **(a) ClientRouter + スクリプト対応**。(b) `transition:name` による共有要素遷移は別 PR）

## 中身

`<ClientRouter />` の追加そのものは 1 行です。作業の実体は**スクリプトの再初期化**でした。

スワップではすでに評価済みのモジュールスクリプトが再実行されないため、各コンポーネントのスクリプトを 2 種類に分ける必要があります。

| 対象 | いつ動くべきか | どこに書くか |
| --- | --- | --- |
| body 内の要素へのバインド（ボタン、dialog、見出しの observer） | **毎回**（要素が差し替わるため） | `onPage()` |
| `document` / `window` / `matchMedia` へのバインド | **1 回だけ**（リスナーが生き残るため） | スクリプト直下 |

このルールと 2 つのヘルパーを `src/lib/lifecycle.ts` に集約しました。次にスクリプトを書く人が推測しなくて済むようにするためです。

要素は毎回新しくなるので、`onPage()` 内で要素リスナーを張り直しても**二重登録にはなりません**（古い要素ごと消えている）。

## コンポーネントごとの対応

- **ThemeToggle** — `astro:after-swap` でテーマを再適用。スワップは遷移先ドキュメントの `<html>` 属性を現在のものに上書きし、静的 HTML には `data-theme` がありません（設定しているのは inline の FOUC 対策スクリプトで、これは再実行されない）。対応しないと**遷移のたびに既定の見た目に戻ります**
- **Header / SearchModal** — `astro:before-swap` で閉じる。スクロールロックは `<html>` 上にあり、スワップを生き延びるため、開いたまま遷移すると**着地先でスクロールが固まります**
- **SearchModal** — 読み込み済みの Pagefind インデックスは遷移をまたいで保持（取得コストが高く、セッション中有効なため）。dialog 側だけ再取得。↑/↓ ハンドラは `document` に移し `dialog.open` でガード
- **Toc** — 新しい observer を作る前に古いものを `disconnect()`。放置すると遷移で切り離された見出しを監視し続けます
- **WorkArchive** — フィルタを再バインド。従来は `/work/` を離れて戻ると**フィルタボタンが無反応**になっていました
- **AuroraBackground** — 要素をキャプチャせず、状態適用時に取得

## 検証（Chrome 実測）

| 確認項目 | 結果 |
| --- | --- |
| クライアント側遷移になっているか（フルリロードでない） | ✅ ページに置いたマーカーが遷移後も生存 |
| `astro:page-load` の発火回数 | ✅ 1 遷移につき 1 回 |
| テーマが遷移をまたいで保持されるか | ✅ `data-theme` / `data-theme-mode` 維持 |
| **リスナーの二重登録がないか** | ✅ 4 ページ移動しながらテーマトグルを 1 クリックずつ → 毎回きっちり 1 段階だけ進む（system→light→dark→system）。メニューも 1 クリック開・1 クリック閉 |
| `/work/` を離れて戻った後のフィルタ | ✅ 「Astro」で絞り込み → 4 件中 2 件表示、`filter-status` も "2 projects shown" |
| メニューを開いたまま遷移した場合のスクロールロック | ✅ 遷移後に `<html>` の `overflow` が解放されている |
| 検索モーダルが遷移後も開くか | ✅ |

## ⚠️ この環境で確認できなかったもの

自動操作しているタブが `document.visibilityState === "hidden"` から抜けられず、**キューイングされるタスクが配送されません**。切り分け済みの事実:

```
syncCustomEvent : 1   ← dispatchEvent は届く
queuedCloseEvent: 0   ← dialog の close イベントは届かない
visibilityState : "hidden"
```

このため以下は**未確認**です。コード上の欠陥ではなく計測できないだけ、という切り分けまでは済んでいます。

- **モーダルを閉じたときのスクロールロック解放** — `close` イベント経由なので配送されない。遷移経由の解放（`astro:before-swap`）は上表のとおり確認済み
- **Toc のスクロールスパイ** — IntersectionObserver のコールバックが非表示タブでは走らない
- **遷移アニメーションの見た目**

お手元で `npm run dev` して、ページ間を移動しながら以下を確認いただけると確実です。

- 遷移がフルリロードにならず、テーマが維持される（ちらつかない）
- 検索モーダルを開いて閉じた後、ページがスクロールできる
- 記事ページで TOC の現在位置ハイライトが追従する
- 連続して行き来してもメニュー / テーマ / 検索 / フィルタが二重発火しない
- Firefox など View Transitions 非対応ブラウザで従来どおり動く

## 品質ゲート

`npm run check` 0エラー / `npm run lint` 0 / `npm run format:check` OK / `npx astro build` 成功
