### PR TITLE
feat(nav): morph card images into the page they open

### DIFF
--- a/src/components/blog/BlogCard.astro
+++ b/src/components/blog/BlogCard.astro
@@ -13,6 +13,8 @@ export interface Props {
   heroImageAlt?: string;
   tags?: string[];
   href: string;
+  /** Entry id, used to pair this card's image with the post's hero image. */
+  slug: string;
   readingTime?: number;
   featured?: boolean;
   class?: string;
@@ -26,6 +28,7 @@ const {
   heroImageAlt,
   tags = [],
   href,
+  slug,
   readingTime,
   featured = false,
   class: className = '',
@@ -43,7 +46,7 @@ const formattedDate = formatDate(pubDate);
         tabindex="-1"
         aria-hidden="true"
       >
-        <div class="blog-card__image">
+        <div class="blog-card__image" transition:name={`post-image-${slug}`}>
           <Picture
             src={heroImage}
             alt={heroImageAlt ?? title}

--- a/src/components/blog/PostGrid.astro
+++ b/src/components/blog/PostGrid.astro
@@ -29,6 +29,7 @@ const showReadingTime = siteConfig.blog.showReadingTime;
           heroImageAlt={post.data.heroImageAlt}
           tags={post.data.tags}
           href={withBase(`/blog/${post.id}/`)}
+          slug={post.id}
           readingTime={showReadingTime ? readingTime(post.body) : undefined}
           featured={post.data.featured}
         />

--- a/src/components/portfolio/ProjectCard.astro
+++ b/src/components/portfolio/ProjectCard.astro
@@ -12,6 +12,8 @@ export interface Props {
   role: string;
   year: number;
   href: string;
+  /** Entry id, used to pair this card's cover with the case study's hero. */
+  slug: string;
   index: number;
   featured?: boolean;
   showTechStack?: boolean;
@@ -27,6 +29,7 @@ const {
   role,
   year,
   href,
+  slug,
   index,
   featured = false,
   showTechStack = true,
@@ -36,7 +39,7 @@ const {
 
 <article class:list={['project', { 'project--featured': featured }]}>
   <GlassCard href={href} padding="none" radius="xl" class="project__card">
-    <div class="project__visual">
+    <div class="project__visual" transition:name={`project-image-${slug}`}>
       <Picture
         src={cover}
         alt={coverAlt}

--- a/src/components/portfolio/WorkArchive.astro
+++ b/src/components/portfolio/WorkArchive.astro
@@ -135,6 +135,7 @@ const rangeEnd = indexOffset + projects.length;
                     role={project.data.role}
                     year={project.data.year}
                     href={withBase(`/work/${project.id}/`)}
+                    slug={project.id}
                     index={indexOffset + index + 1}
                     featured={project.data.featured}
                     showTechStack={showTechStack}

--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -112,7 +112,10 @@ const linkedInUrl = `https://www.linkedin.com/sharing/share-offsite/?url=${encod
 
         {
           post.data.heroImage && (
-            <div class="post-hero-image">
+            <div
+              class="post-hero-image"
+              transition:name={`post-image-${post.id}`}
+            >
               <Picture
                 src={post.data.heroImage}
                 alt={post.data.heroImageAlt ?? post.data.title}

--- a/src/pages/work/[...slug].astro
+++ b/src/pages/work/[...slug].astro
@@ -71,7 +71,10 @@ const projectLinks = [
             <p class="case-hero__summary">{project.data.summary}</p>
           </div>
 
-          <div class="case-hero__image">
+          <div
+            class="case-hero__image"
+            transition:name={`project-image-${project.id}`}
+          >
             <Picture
               src={project.data.cover}
               alt={project.data.coverAlt ?? project.data.title}


### PR DESCRIPTION
Closes #43（(a) は #78 でマージ済み。これが **(b) 共有要素遷移**）

## 中身

一覧のサムネイルと詳細ページのヒーロー画像に同じ `transition:name` を付け、遷移時にブラウザが画像を持ち越すようにしました。

| 付与先 | 名前 |
| --- | --- |
| `BlogCard` の `.blog-card__image` / `blog/[...slug]` の `.post-hero-image` | `post-image-<id>` |
| `ProjectCard` の `.project__visual` / `work/[...slug]` の `.case-hero__image` | `project-image-<id>` |

## 設計上の判断

**名前は entry id から作り、`slug` を明示的に prop で渡しています。** href から切り出す手もありますが、それだと URL の組み立て方に対の成立が依存してしまいます。

**名前は画像そのものではなく、画像を囲むボックスに付けました。** カードとヒーローでは同じ写真でもトリミングが違うため、生の `<img>` をモーフさせるとそのトリミングを飛び越えて動いてしまいます。読者が実際に見ている「切り取られた形」を morph させるほうが自然です。

blog / work とも featured をグリッドから除外しているので、**同じ entry が 1 ページに二度描画されることはなく**、名前が二重に取られる心配もありません。ヒーロー画像を持たない記事は相方が存在しないだけで、Astro の既定のクロスフェードにフォールバックします。

## 検証

**静的検証**（ビルド成果物）:

- 一覧と詳細で共有される `view-transition-name` がちょうど 1 つで、期待どおりの名前であること
  - `blog/index` ↔ `blog/getting-started` → `post-image-getting-started`
  - `work/index` ↔ `work/northstar-civic-platform` → `project-image-northstar-civic-platform`
- **全 HTML ページで共有要素名の重複 0 件**（1 ページ内で同じ名前が 2 要素に付くと遷移が壊れるため）
- markup 上の scope 属性数: blog/index 2（記事 2 件）/ work/index 4（案件 4 件）/ 詳細ページ 1

**ブラウザ実測**（Chrome、実際にクリックして遷移）:

```
work 一覧の 4 枚: project-image-northstar-civic-platform ほか 4 種すべて異なる
  → 1 枚目をクリック → /work/northstar-civic-platform/ に着地
  → ヒーローの name が project-image-northstar-civic-platform（クリックしたカードと一致）

blog 一覧の 2 枚: post-image-getting-started / post-image-design-principles（重複なし）
  → /blog/getting-started/ に着地 → ヒーローの name が一致
```

JS エラーなし。

## ⚠️ 未確認

**モーフの見た目そのものは確認できていません。** #78 と同じく自動操作タブが `visibilityState: "hidden"` のままで、View Transitions のアニメーションが走りません。対の成立（同じ name が両ページの正しい要素に付く）までは上記のとおり実測済みなので、残るは見え方だけです。

お手元で `npm run dev` して、一覧 → 詳細のクリックで画像が繋がって動くかご確認ください。あわせて `prefers-reduced-motion` でアニメーションが無効になること、Firefox など非対応ブラウザで従来どおり遷移することも見ていただけると万全です。

## 品質ゲート

`npm run check` 0エラー / `npm run lint` 0 / `npm run format:check` OK / `npx astro build` 成功